### PR TITLE
Create virtual environment for Python packages in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
           brew install \
             gmp
 
+      - name: Python Environment Setup
+        run: |
+          python3 -m venv ./.venv
+          echo "$PWD/.venv/bin" >> $GITHUB_PATH
+
       # install previous version of setuptools as temporary fix
       # see also recommendations here: https://github.com/pypa/setuptools/issues/3227
       - name: Python Dependencies (macOS)


### PR DESCRIPTION
Fixes CI failures due to [PEP 668](https://peps.python.org/pep-0668/).