### PR TITLE
Add missing Python dependency to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: python3 -m pip install 'setuptools<61'
 
       - name: Python Dependencies (all)
-        run: python3 -m pip install Cython pytest toml
+        run: python3 -m pip install Cython pytest pyparsing toml
 
       - name: Python Dependencies (all)
         run: python3 -m pip install scikit-build


### PR DESCRIPTION
Install `pyparsing` in CI because cvc5 depends on it now.