### PR TITLE
Update setuptools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,6 @@ jobs:
           python3 -m venv ./.venv
           echo "$PWD/.venv/bin" >> $GITHUB_PATH
 
-      # install previous version of setuptools as temporary fix
-      # see also recommendations here: https://github.com/pypa/setuptools/issues/3227
-      - name: Python Dependencies (macOS)
-        if: runner.os == 'macOS'
-        run: python3 -m pip install 'setuptools<61'
-
       - name: Python Dependencies (all)
         run: python3 -m pip install Cython pytest pyparsing toml
 

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -14,5 +14,6 @@ setup(name='pono',
       license='BSD',
       install_requires=['smt-switch'],
       test_requires=['pytest'],
+      packages=[],
       package_data={'': ['pono.so']},
       zip_safe=False)


### PR DESCRIPTION
Remove the temporary solution pinning setuptools to version 60, because that version no longer works with Python 3.12. The actual solution is to specify `packages=[]` in `setup.py`.