### PR TITLE
Remove unneeded librt causing issues during static compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,8 +52,6 @@ if (BISON_FOUND)
   link_directories("${BISON_PARENT_DIR}/../lib/")
 endif()
 
-find_library(LIBRT rt)
-
 message("-- FOUND FLEX EXECUTABLE: ${FLEX_EXECUTABLE}")
 message("-- FOUND FLEX INCLUDE DIRS: ${FLEX_INCLUDE_DIRS}")
 
@@ -264,10 +262,6 @@ target_link_libraries(pono-lib PUBLIC "${GMPXX_LIBRARIES}")
 target_link_libraries(pono-lib PUBLIC "${GMP_LIBRARIES}")
 target_link_libraries(pono-lib PUBLIC pthread)
 target_link_libraries(pono-lib PUBLIC y)
-
-if (LIBRT)
-  target_link_libraries(pono-lib PUBLIC ${LIBRT})
-endif()
 
 if (GOOGLE_PERF)
   target_link_libraries(pono-lib PUBLIC ${GOOGLE_PERF})


### PR DESCRIPTION
Linking with `librt` has not been needed since glibc 2.17, released in 2012. Adding this flag also causes CMake to mess up the linking command line when compiling the pono binary statically.

`libpthread` was also merged into glibc in version 2.34, released 2021. Once an updated version gets propagated to all maintained distros, we can remove that too.