### PR TITLE
Update Bison to fix Clang error

### DIFF
--- a/contrib/setup-bison.sh
+++ b/contrib/setup-bison.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-BISON_VERSION=3.7
+BISON_VERSION=3.7.4
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DEPS=$DIR/../deps

--- a/contrib/setup-bison.sh
+++ b/contrib/setup-bison.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+BISON_VERSION=3.7
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DEPS=$DIR/../deps
 
@@ -12,17 +14,17 @@ if [ -d "$DEPS/bison" ]; then
     exit 1
 fi
 
-curl http://ftp.gnu.org/gnu/bison/bison-3.7.tar.gz --output $DEPS/bison-3.7.tar.gz
+curl http://ftp.gnu.org/gnu/bison/bison-$BISON_VERSION.tar.gz --output $DEPS/bison-$BISON_VERSION.tar.gz
 
-if [ ! -f "$DEPS/bison-3.7.tar.gz" ]; then
-    echo "It seems like downloading bison to $DEPS/bison-3.7.tar.gz failed"
+if [ ! -f "$DEPS/bison-$BISON_VERSION.tar.gz" ]; then
+    echo "It seems like downloading bison to $DEPS/bison-$BISON_VERSION.tar.gz failed"
     exit 1
 fi
 
 cd $DEPS
-tar -xzf bison-3.7.tar.gz
-rm bison-3.7.tar.gz
-mv ./bison-3.7 ./bison
+tar -xzf bison-$BISON_VERSION.tar.gz
+rm bison-$BISON_VERSION.tar.gz
+mv ./bison-$BISON_VERSION ./bison
 cd bison
 mkdir bison-install
 ./configure --prefix $DEPS/bison/bison-install --exec-prefix $DEPS/bison/bison-install


### PR DESCRIPTION
Clang 16 made implicit function pointer conversions in C an error (they previously emitted a warning). Bison bundles `gnulib`, which has a file (`lib/objstack.c`) that violates this in earlier versions. This got fixed with [0cc3971](https://git.savannah.gnu.org/cgit/gnulib.git/commit/lib/obstack.c?id=0cc39712803ade7b2d4b89c36b143dad72404063). Bison pulled this fix in in [98c35e0](http://git.savannah.gnu.org/cgit/bison.git/commit/?id=98c35e0025f43838d4c451553a4cf8b345b047f8), which is first included in version 3.7.4.

We currently download Bison 3.7 in the contrib script, but the latest macOS image on GitHub has Clang, so this causes errors is CI. Therefore, this PR updates Bison to 3.7.4.

Also see https://code.videolan.org/videolan/vlc/-/merge_requests/2399 for a similar change.