### PR TITLE
Exclude MathSAT from CI runs on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
         run: python3 -m pip install scikit-build
 
       - name: Download MathSAT
+        if: runner.os != 'macOS'
         run: ./ci-scripts/setup-msat.sh --auto-yes
 
       - name: Setup Flex
@@ -51,12 +52,23 @@ jobs:
       - name: Setup Btor2Tools
         run: ./contrib/setup-btor2tools.sh
 
-      - name: Setup Smt-Switch
-        run: |
-          ./contrib/setup-smt-switch.sh --with-msat --python
-          python3 -m pip install -e ./deps/smt-switch/build/python
+      - name: Setup Smt-Switch (macOS)
+        if: runner.os == 'macOS'
+        run: ./contrib/setup-smt-switch.sh --python
 
-      - name: Configure
+      - name: Setup Smt-Switch (non-macOS)
+        if: runner.os != 'macOS'
+        run: ./contrib/setup-smt-switch.sh --with-msat --python
+
+      - name: Set up Python bindings for smt-switch
+        run: python3 -m pip install -e ./deps/smt-switch/build/python
+
+      - name: Configure (macOS)
+        if: runner.os == 'macOS'
+        run: ./configure.sh --debug --python
+
+      - name: Configure (non-macOS)
+        if: runner.os != 'macOS'
         run: ./configure.sh --with-msat --debug --python
 
       - name: Build


### PR DESCRIPTION
The MathSAT version we use does not support arm64, but the `macos-latest` images provided by GitHub are now ARM-only, see https://github.com/actions/runner-images/issues/9741.

Newer MathSAT versions do exist for ARM-based macOS, but all of those currently have bugs that make them crash on a lot of our benchmarks.