### PR TITLE
Do not limit depth when cloning btor2tools

### DIFF
--- a/contrib/setup-btor2tools.sh
+++ b/contrib/setup-btor2tools.sh
@@ -10,7 +10,7 @@ mkdir -p $DEPS
 
 if [ ! -d "$DEPS/btor2tools" ]; then
     cd $DEPS
-    git clone --depth 1 https://github.com/Boolector/btor2tools.git btor2tools
+    git clone https://github.com/Boolector/btor2tools.git btor2tools
     cd btor2tools
     git checkout -f $BTOR2TOOLS_VERSION
     CFLAGS="-fPIC" ./configure.sh --static


### PR DESCRIPTION
With the current setup, when a new commit gets pushed to the btor2tools repo, our CI starts failing.