### PR TITLE
Exclude state variables without update functions in simple path check

### DIFF
--- a/core/ts.cpp
+++ b/core/ts.cpp
@@ -628,6 +628,17 @@ bool TransitionSystem::no_next(const Term & term) const
   return contains(term, UnorderedTermSetPtrVec{ &statevars_, &inputvars_ });
 }
 
+smt::UnorderedTermSet TransitionSystem::no_next_states() const
+{
+  smt::UnorderedTermSet no_next_states;
+  for (const auto & sv : statevars_) {
+    if (state_updates_.find(sv) == state_updates_.end()) {
+      no_next_states.insert(sv);
+    }
+  }
+  return no_next_states;
+}
+
 void TransitionSystem::drop_state_updates(const TermVec & svs)
 {
   for (const auto & sv : svs) {

--- a/core/ts.h
+++ b/core/ts.h
@@ -252,6 +252,12 @@ class TransitionSystem
     return state_updates_;
   };
 
+  /* Returns the set of state variables with no update function. */
+  const smt::UnorderedTermSet & statevars_with_no_update() const
+  {
+    return no_state_updates_;
+  };
+
   /* @return the named terms mapping */
   const std::unordered_map<std::string, smt::Term> & named_terms() const
   {
@@ -302,9 +308,6 @@ class TransitionSystem
   /* Returns true iff all the symbols in the formula are inputs and current
    * states */
   bool no_next(const smt::Term & term) const;
-
-  /* Returns the set of states with no update function. */
-  smt::UnorderedTermSet no_next_states() const;
 
   /** EXPERTS ONLY
    *  Drop the state update for these variables and rebuild the system
@@ -508,6 +511,9 @@ class TransitionSystem
 
   // next state update function
   smt::UnorderedTermMap state_updates_;
+
+  // states with no next state update function
+  smt::UnorderedTermSet no_state_updates_;
 
   // maps states and inputs variables to next versions
   // note: the next state variables are only used

--- a/core/ts.h
+++ b/core/ts.h
@@ -303,6 +303,9 @@ class TransitionSystem
    * states */
   bool no_next(const smt::Term & term) const;
 
+  /* Returns the set of states with no update function. */
+  smt::UnorderedTermSet no_next_states() const;
+
   /** EXPERTS ONLY
    *  Drop the state update for these variables and rebuild the system
    *  @param svs the state variables to drop updates for

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -265,7 +265,7 @@ Term KInduction::simple_path_constraint(int i, int j)
   assert(ts_.statevars().size());
 
   Term disj = false_;
-  const auto no_next_states = ts_.no_next_states();
+  const auto no_next_states = ts_.statevars_with_no_update();
   for (const auto &v : ts_.statevars()) {
     // Skip states without updates, because those cause spurious transitions.
     // k=0 is excluded as they could still have initial values.

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -265,7 +265,13 @@ Term KInduction::simple_path_constraint(int i, int j)
   assert(ts_.statevars().size());
 
   Term disj = false_;
+  const auto no_next_states = ts_.no_next_states();
   for (const auto &v : ts_.statevars()) {
+    // Skip states without updates, because those cause spurious transitions.
+    // k=0 is excluded as they could still have initial values.
+    if (i > 0 && j > 0 && no_next_states.find(v) != no_next_states.end()) {
+      continue;
+    }
     Term vi = unroller_.at_time(v, i);
     Term vj = unroller_.at_time(v, j);
     Term eq = solver_->make_term(PrimOp::Equal, vi, vj);

--- a/tests/encoders/test_btor2_ts_copy_equal.cpp
+++ b/tests/encoders/test_btor2_ts_copy_equal.cpp
@@ -46,6 +46,8 @@ TEST_P(CopyUnitTests, CopyFromDefault)
   FunctionalTransitionSystem fts_copy(fts, tt);
 
   EXPECT_EQ(fts.statevars().size(), fts_copy.statevars().size());
+  EXPECT_EQ(fts.statevars_with_no_update().size(),
+            fts_copy.statevars_with_no_update().size());
   EXPECT_EQ(fts.inputvars().size(), fts_copy.inputvars().size());
   EXPECT_EQ(fts.named_terms().size(), fts_copy.named_terms().size());
   EXPECT_EQ(fts.state_updates().size(), fts_copy.state_updates().size());
@@ -124,6 +126,8 @@ TEST_P(CopyUnitTests, CopyToDefault)
   fts_copy = FunctionalTransitionSystem(fts, tt);
 
   EXPECT_EQ(fts.statevars().size(), fts_copy.statevars().size());
+  EXPECT_EQ(fts.statevars_with_no_update().size(),
+            fts_copy.statevars_with_no_update().size());
   EXPECT_EQ(fts.inputvars().size(), fts_copy.inputvars().size());
   EXPECT_EQ(fts.named_terms().size(), fts_copy.named_terms().size());
   EXPECT_EQ(fts.state_updates().size(), fts_copy.state_updates().size());
@@ -149,6 +153,10 @@ TEST_P(CopyUnitTests, CopyToDefault)
   // VARS -- these should be exactly the same
   for (auto v : fts.inputvars()) {
     EXPECT_TRUE(fts_2.inputvars().find(v) != fts_2.inputvars().end());
+  }
+  for (auto v : fts.statevars_with_no_update()) {
+    EXPECT_TRUE(fts_2.statevars_with_no_update().find(v)
+                != fts_2.statevars_with_no_update().end());
   }
   for (auto v : fts.statevars()) {
     EXPECT_TRUE(fts_2.statevars().find(v) != fts_2.statevars().end());

--- a/tests/test_engines.cpp
+++ b/tests/test_engines.cpp
@@ -221,18 +221,18 @@ TEST_P(InterpWinTests, BmcFail)
   ASSERT_EQ(r, ProverResult::UNKNOWN);
 }
 
-TEST_P(InterpWinTests, BmcSimplePathFail)
+TEST_P(InterpWinTests, BmcSimplePathWin)
 {
   BmcSimplePath bsp(*true_p, *ts, s);
   ProverResult r = bsp.check_until(10);
-  ASSERT_EQ(r, ProverResult::UNKNOWN);
+  ASSERT_EQ(r, ProverResult::TRUE);
 }
 
-TEST_P(InterpWinTests, KInductionFail)
+TEST_P(InterpWinTests, KInductionWin)
 {
   KInduction kind(*true_p, *ts, s);
   ProverResult r = kind.check_until(10);
-  ASSERT_EQ(r, ProverResult::UNKNOWN);
+  ASSERT_EQ(r, ProverResult::TRUE);
 }
 
 TEST_P(InterpWinTests, InterpWin)

--- a/tests/test_ts.cpp
+++ b/tests/test_ts.cpp
@@ -38,10 +38,12 @@ TEST_P(TSUnitTests, FTS_IsFunc)
   Term x = fts.make_statevar("x", bvsort);
   EXPECT_FALSE(fts.is_deterministic());
   EXPECT_TRUE(fts.is_functional());
+  EXPECT_EQ(fts.statevars_with_no_update(), UnorderedTermSet({x}));
 
   fts.assign_next(x, s->make_term(BVAdd, x, s->make_term(1, bvsort)));
   EXPECT_TRUE(fts.is_functional());
   EXPECT_TRUE(fts.is_deterministic());
+  EXPECT_EQ(fts.statevars_with_no_update().size(), 0);
 
   fts.add_constraint(fts.make_term(BVUge, x, s->make_term(2, bvsort)));
   // any kind of constrains makes the system non-deterministic
@@ -53,10 +55,15 @@ TEST_P(TSUnitTests, FTS_IsFunc)
   EXPECT_TRUE(fts.is_functional());
   // still can't be deterministic because of the constraint
   EXPECT_FALSE(fts.is_deterministic());
+  EXPECT_EQ(fts.statevars_with_no_update().size(), 0);
+
+  Term z = fts.make_statevar("z", bvsort);
+  EXPECT_EQ(fts.statevars_with_no_update(), UnorderedTermSet({z}));
 
   TransitionSystem ts_copy = fts;
   EXPECT_EQ(fts.is_functional(), ts_copy.is_functional());
   EXPECT_EQ(fts.is_deterministic(), ts_copy.is_deterministic());
+  EXPECT_EQ(fts.statevars_with_no_update(), ts_copy.statevars_with_no_update());
   EXPECT_EQ(ts_copy, fts);
   ts_copy.set_init(ts_copy.make_term(Equal, x, ts_copy.make_term(1, bvsort)));
   EXPECT_NE(ts_copy, fts);


### PR DESCRIPTION
If there are state variables that are, e.g., used in the property, but do not have an update function, the simple path check in k-induction  and BMC will never succeed. This is because we can always pick an arbitrary (new) value for this variable and thus construct a "new" state, even if, in reality, we are in a loop.

Such variables should in reality be inputs. However, such a transformation is not completely straightforward, as they could still have an initial value. For now, as a simple solution, we simply exclude them from the simple path checks.