### PR TITLE
Change minimum CMake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(pono)
 

--- a/tests/CMakeLists.txt.in
+++ b/tests/CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(googletest-download NONE)
 


### PR DESCRIPTION
Current CMake versions print warnings that CMake < 3.5 is deprecated and support for it will be removed soon. CMake 3.5.0 was released in December 2018, so this should not affect any reasonably up-to-date installation.