### PR TITLE
Revert "Change minimum CMake version to 3.5"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.1)
 
 project(pono)
 

--- a/tests/CMakeLists.txt.in
+++ b/tests/CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.1)
 
 project(googletest-download NONE)
 


### PR DESCRIPTION
Reverts stanford-centaur/pono#354. That change breaks compilation of the static pono executable on systems where there are both static and dynamic versions of `libgmp`.