### PR TITLE
Only print COI traversal for verbosity >=4

### DIFF
--- a/utils/fcoi.cpp
+++ b/utils/fcoi.cpp
@@ -43,7 +43,7 @@ void FunctionalConeOfInfluence::compute_coi(const TermVec & terms)
   clear();
 
   assert(coi_visited_terms_.empty());
-  if (verbosity_ >= 3) print_coi_info(terms);
+  if (verbosity_ >= 4) print_coi_info(terms);
 
   UnorderedTermSet new_coi_state_vars;
   UnorderedTermSet new_coi_input_vars;


### PR DESCRIPTION
Printing the traversal is *very* verbose, even relative to the other stuff printed at verbosity level 3.