### PR TITLE
Do not build tests for `make all` or `make install`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Test C++
         run: |
           cd build
-          make test
+          make check
 
       - name: Install Python Bindings
         run: python3 -m pip install -e ./build/python[test,pysmt]

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Pono was awarded the Oski Award under its original name _cosa2_ at [HWMCC'19](ht
   * if building with mathsat, also include `--with-msat` as an option to `configure.sh`
 * Run `cd build`.
 * Run `make`.
+* [optional] Run `make check` to build and run the tests.
 
 ### Dependencies
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,7 +36,7 @@ if (WITH_MSAT)
   add_definitions(-DWITH_MSAT)
 endif()
 
-add_library(pono-test-lib "${PONO_LIB_TYPE}"
+add_library(pono-test-lib EXCLUDE_FROM_ALL "${PONO_LIB_TYPE}"
   "${CMAKE_CURRENT_SOURCE_DIR}/common_ts.cpp"
 )
 
@@ -44,10 +44,14 @@ add_library(pono-test-lib "${PONO_LIB_TYPE}"
 target_include_directories(pono-test-lib PUBLIC "${INCLUDE_DIRS}")
 target_link_libraries(pono-test-lib pono-lib)
 
+# Create `make check` target that (re-)builds tests before trying to run them.
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+
 macro(pono_add_test name)
-  add_executable(${name} "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cpp")
+  add_executable(${name} EXCLUDE_FROM_ALL "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cpp")
   target_link_libraries(${name} gtest gtest_main)
   target_link_libraries(${name} pono-test-lib) # also includes pono-lib because it's linked
+  add_dependencies(check ${name})
   add_test(NAME ${name} COMMAND ${name})
 endmacro()
 


### PR DESCRIPTION
This enables developers to iterate faster by not having to relink all the test binaries every time they make a change to a file. The tests can still be build and run with the new "check" target.