### PR TITLE
Fix handling of quoted symbol names

### DIFF
--- a/core/unroller.cpp
+++ b/core/unroller.cpp
@@ -14,12 +14,13 @@
  **
  **/
 
-#include <assert.h>
+#include "unroller.h"
+
 #include <algorithm>
+#include <cassert>
 
 #include "smt-switch/utils.h"
-
-#include "unroller.h"
+#include "utils/syntax_analysis_common.h"
 
 using namespace smt;
 using namespace std;
@@ -95,9 +96,10 @@ Term Unroller::var_at_time(const Term & v, unsigned int k)
     return it->second;
   }
 
-  std::string name = v->to_string();
+  std::string name = syntax_analysis::name_desanitize(v->to_string());
   name += time_id_ + std::to_string(k);
-  Term timed_v = solver_->make_symbol(name, v->get_sort());
+  Term timed_v =
+      solver_->make_symbol(syntax_analysis::name_sanitize(name), v->get_sort());
   cache[v] = timed_v;
   untime_cache_[timed_v] = v;
   var_times_[timed_v] = k;

--- a/modifiers/implicit_predicate_abstractor.cpp
+++ b/modifiers/implicit_predicate_abstractor.cpp
@@ -18,12 +18,12 @@
 #include "modifiers/implicit_predicate_abstractor.h"
 
 #include "assert.h"
-#include "utils/logger.h"
 #include "smt/available_solvers.h"
+#include "utils/logger.h"
+#include "utils/syntax_analysis_common.h"
 
 using namespace smt;
 using namespace std;
-
 
 namespace pono {
 
@@ -64,7 +64,6 @@ ImplicitPredicateAbstractor::ImplicitPredicateAbstractor(
     throw PonoException(
         "Implicit predicate abstraction needs a relational abstract system");
   }
-
 }
 
 Term ImplicitPredicateAbstractor::abstract(Term & t)
@@ -217,8 +216,9 @@ UnorderedTermSet ImplicitPredicateAbstractor::do_abstraction()
     // for incrementality
     // only create new variables if not present in cache
     if (abstraction_cache_.find(nv) == abstraction_cache_.end()) {
-      Term abs_nv = abs_rts_.make_inputvar(nv->to_string() + "^",
-                                           nv->get_sort());
+      auto abs_var_name = syntax_analysis::name_sanitize(
+          syntax_analysis::name_desanitize(nv->to_string()) + "^");
+      Term abs_nv = abs_rts_.make_inputvar(abs_var_name, nv->get_sort());
       // map next var to this abstracted next var
       update_term_cache(nv, abs_nv);
     }


### PR DESCRIPTION
When an SMT-LIB symbol contains special characters, it must be quoted by surrounding it with `|`. When we get such a symbol back from a solver, we must unquote it before doing any sort of name manipulation on it, then re-add the quoting.