### PR TITLE
Add an option "--version" to print version and exit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,17 @@ set(PONO_MAJOR 0)   # Major component of Pono version
 set(PONO_MINOR 1)   # Minor component of Pono version
 set(PONO_RELEASE 1) # Release component of Pono version
 
+# Retrieve the current version via Git
+execute_process(
+    COMMAND git describe --always --dirty
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    RESULT_VARIABLE GIT_DESCRIBE_STATUS
+    OUTPUT_VARIABLE PONO_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+if(GIT_DESCRIBE_STATUS AND NOT GIT_DESCRIBE_STATUS EQUAL 0)
+    set(PONO_VERSION "v${PONO_MAJOR}.${PONO_MINOR}.${PONO_RELEASE}")
+endif()
+
 # handle different versions of CMake
 if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0 AND NOT APPLE)
   set(CMAKE_CXX17_STANDARD_COMPILE_OPTION "-std=c++17")
@@ -234,6 +245,7 @@ endif()
 
 add_library(pono-lib "${PONO_LIB_TYPE}" ${SOURCES})
 set_target_properties(pono-lib PROPERTIES OUTPUT_NAME pono)
+target_compile_definitions(pono-lib PRIVATE "-DPONO_VERSION=\"${PONO_VERSION}\"")
 
 target_include_directories(pono-lib PUBLIC ${INCLUDE_DIRS})
 

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -23,6 +23,10 @@
 #include "optionparser.h"
 #include "utils/exceptions.h"
 
+#ifndef PONO_VERSION
+#define PONO_VERSION "unknown"
+#endif
+
 using namespace std;
 
 /************************************* Option Handling setup
@@ -32,6 +36,7 @@ enum optionIndex
 {
   UNKNOWN_OPTION,
   HELP,
+  VERSION,
   ENGINE,
   BOUND,
   PROP,
@@ -137,6 +142,12 @@ const option::Descriptor usage[] = {
     "USAGE: pono [options] <btor file>\n\n"
     "Options:" },
   { HELP, 0, "", "help", Arg::None, "  --help \tPrint usage and exit." },
+  { VERSION,
+    0,
+    "",
+    "version",
+    Arg::None,
+    "  --version \tPrint version and exit." },
   { ENGINE,
     0,
     "e",
@@ -624,6 +635,11 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
   if (options[HELP] || argc == 0) {
     option::printUsage(cout, usage);
     // want to exit main at top-level
+    return ERROR;
+  }
+
+  if (options[VERSION]) {
+    cout << PONO_VERSION << endl;
     return ERROR;
   }
 

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -9,8 +9,8 @@ from setuptools import setup
 
 setup(name='pono',
       long_description="Python bindings for the model checker Pono",
-      version='${PONO_MAJOR}.${PONO_MINOR}.${PONO_RELEASE}',
-      url='https://github.com/upscale-project/pono',
+      version='${PONO_VERSION}',
+      url='https://github.com/stanford-centaur/pono',
       license='BSD',
       install_requires=['smt-switch'],
       test_requires=['pytest'],

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(name='pono',
       long_description="Python bindings for the model checker Pono",
-      version='${PONO_VERSION}',
+      version='${PONO_MAJOR}.${PONO_MINOR}.${PONO_RELEASE}',
       url='https://github.com/stanford-centaur/pono',
       license='BSD',
       install_requires=['smt-switch'],


### PR DESCRIPTION
This PR introduces a new option `--version`:

```
  --version  Print version and exit.
```

Example usage:

```bash
$ ./pono --version
v0.1.1-237-g35cadb4
```

The version is obtained from running `git describe --always --dirty`.
This feature is useful if one wants to determine the version of the code from which the binary is compiled.