### PR TITLE
Update IC3ia to version 23.05

### DIFF
--- a/contrib/setup-ic3ia.sh
+++ b/contrib/setup-ic3ia.sh
@@ -25,7 +25,7 @@ mkdir -p $DEPS
 cd $DEPS
 
 msat_home="$DEPS/mathsat"
-ic3ia_version=ic3ia-22.07
+ic3ia_version=ic3ia-23.05
 
 while [ $# -gt 0 ]
 do


### PR DESCRIPTION
The old version 22.07 of IC3ia is no longer available for download.

The new IC3ia 23.05 can be built with Pono locally on my laptop without a problem.