### PR TITLE
Check if user-specified bound is valid

### DIFF
--- a/options/options.cpp
+++ b/options/options.cpp
@@ -670,7 +670,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case ENGINE: engine_ = to_engine(opt.arg); break;
         case BOUND:
           bound_ = atoi(opt.arg);
-          if (bound_ >= INT_MAX) {
+          if (bound_ == INT_MAX) {
             throw PonoException("--bound must be less than "
                                 + std::to_string(INT_MAX) + ".");
           }

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -16,6 +16,7 @@
 
 #include "options/options.h"
 
+#include <climits>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -667,7 +668,13 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case HELP:
           // not possible, because handled further above and exits the program
         case ENGINE: engine_ = to_engine(opt.arg); break;
-        case BOUND: bound_ = atoi(opt.arg); break;
+        case BOUND:
+          bound_ = atoi(opt.arg);
+          if (bound_ >= INT_MAX) {
+            throw PonoException("--bound must be less than "
+                                + std::to_string(INT_MAX) + ".");
+          }
+          break;
         case PROP: prop_idx_ = atoi(opt.arg); break;
         case VERBOSITY: verbosity_ = atoi(opt.arg); break;
         case RANDOM_SEED: random_seed_ = atoi(opt.arg); break;


### PR DESCRIPTION
This PR adds a simple check for the user-specified bound (`--bound`),
ensuring it is less than `INTMAX`.

The upper limit is set to prevent potential integer overflow when a monitor is used,
as the bound is internally incremented by one (see #356).