### PR TITLE
Promote inputs to states in Btor2's bad

### DIFF
--- a/frontends/btor2_encoder.cpp
+++ b/frontends/btor2_encoder.cpp
@@ -413,6 +413,17 @@ void BTOR2Encoder::parse(const std::string filename)
     } else if (l_->tag == BTOR2_TAG_bad) {
       Term bad = bv_to_bool(termargs_[0]);
       Term prop = solver_->make_term(Not, bad);
+
+      // BTOR2 allows properties (negation of bad) over inputs
+      // in Pono these need to be promoted to state variables
+      UnorderedTermSet free_vars;
+      get_free_symbolic_consts(bad, free_vars);
+      for (const auto & v : free_vars) {
+        if (ts_.is_input_var(v)) {
+          ts_.promote_inputvar(v);
+        }
+      }
+
       propvec_.push_back(prop);
       terms_[l_->id] = prop;
     } else if (l_->tag == BTOR2_TAG_justice) {

--- a/modifiers/mod_ts_prop.cpp
+++ b/modifiers/mod_ts_prop.cpp
@@ -122,9 +122,8 @@ TransitionSystem promote_inputvars(const TransitionSystem & ts)
 
   // copy over inputs but make them statevars
   for (const auto & iv : ts.inputvars()) {
-    Term iv_next =
-        solver->make_symbol(iv->to_string() + ".next", iv->get_sort());
-    new_ts.add_statevar(iv, iv_next);
+    new_ts.add_inputvar(iv);
+    new_ts.promote_inputvar(iv);
   }
 
   // set init


### PR DESCRIPTION
This PR fixes the wrong proof in #377.

However, the fix applies only to Btor2 models.
The soundness issue may still occur with other models (see https://github.com/stanford-centaur/pono/issues/377#issuecomment-2759013003).