### PR TITLE
Rename Btor2 symbols internally

### DIFF
--- a/frontends/btor2_encoder.h
+++ b/frontends/btor2_encoder.h
@@ -51,6 +51,10 @@ class BTOR2Encoder
   {
     return no_next_states_;
   }
+  const std::unordered_map<std::string, std::string> & get_symbol_map() const
+  {
+    return symbol_map_;
+  }
 
  protected:
   // converts booleans to bitvector of size one

--- a/frontends/btor2_encoder.h
+++ b/frontends/btor2_encoder.h
@@ -78,6 +78,9 @@ class BTOR2Encoder
   std::map<uint64_t, smt::Term> no_next_states_;
   // record the renaming done by the `preprocess` pass
   std::unordered_map<uint64_t, std::string> state_renaming_table_;
+  // a mapping from the internally-assigned names ("intput/state{btor2_id}")
+  // to the original names in Btor2
+  std::unordered_map<std::string, std::string> symbol_map_;
 
   std::unordered_map<int, smt::Sort> sorts_;
   std::unordered_map<int, smt::Term> terms_;

--- a/pono.cpp
+++ b/pono.cpp
@@ -309,7 +309,7 @@ int main(int argc, char ** argv)
         if (cex.size()) {
           print_witness_btor(btor_enc, cex, fts);
           if (!pono_options.vcd_name_.empty()) {
-            VCDWitnessPrinter vcdprinter(fts, cex);
+            VCDWitnessPrinter vcdprinter(fts, cex, btor_enc.get_symbol_map());
             vcdprinter.dump_trace_to_file(pono_options.vcd_name_);
           }
         }

--- a/printers/vcd_witness_printer.cpp
+++ b/printers/vcd_witness_printer.cpp
@@ -22,6 +22,7 @@
 
 #include "frontends/btor2_encoder.h"
 #include "utils/logger.h"
+#include "utils/str_util.h"
 
 using namespace smt;
 using namespace std;
@@ -151,7 +152,9 @@ static std::string as_decimal(std::string val)
 // ------------- CLASS FUNCTIONS ------------------ //
 
 VCDWitnessPrinter::VCDWitnessPrinter(
-    const TransitionSystem & ts, const std::vector<smt::UnorderedTermMap> & cex)
+    const TransitionSystem & ts,
+    const std::vector<smt::UnorderedTermMap> & cex,
+    const std::unordered_map<std::string, std::string> & symbol_map)
     : inputs_(ts.inputvars()),
       states_(ts.statevars()),
       named_terms_(ts.named_terms()),
@@ -171,7 +174,9 @@ VCDWitnessPrinter::VCDWitnessPrinter(
     if (sk == smt::ARRAY) {
       continue;  // let's not worry about array so far
     }
-    check_insert_scope(name_term_pair.first, is_reg, name_term_pair.second);
+    check_insert_scope(lookup_or_key(symbol_map, name_term_pair.first),
+                       is_reg,
+                       name_term_pair.second);
   }
 
   for (auto && state : states_) {
@@ -202,15 +207,19 @@ VCDWitnessPrinter::VCDWitnessPrinter(
         if (tmp->get_op().is_null() && tmp->is_value())
           has_default_value = true;
       }  // for each frame, collect
-      check_insert_scope_array(
-          state->to_string(), indices, has_default_value, state);
+      check_insert_scope_array(lookup_or_key(symbol_map, state->to_string()),
+                               indices,
+                               has_default_value,
+                               state);
     } else
-      check_insert_scope(state->to_string(), true, state);
+      check_insert_scope(
+          lookup_or_key(symbol_map, state->to_string()), true, state);
   }
 
   for (auto && input : inputs_) {
     if (input->get_sort()->get_sort_kind() == smt::ARRAY) continue;
-    check_insert_scope(input->to_string(), false, input);
+    check_insert_scope(
+        lookup_or_key(symbol_map, input->to_string()), false, input);
   }
 
 }  // VCDWitnessPrinter -- constructor

--- a/printers/vcd_witness_printer.h
+++ b/printers/vcd_witness_printer.h
@@ -120,8 +120,10 @@ class VCDWitnessPrinter
   void DumpValues(std::ostream & fout) const;
 
  public:
-  VCDWitnessPrinter(const TransitionSystem & ts,
-                    const std::vector<smt::UnorderedTermMap> & cex);
+  VCDWitnessPrinter(
+      const TransitionSystem & ts,
+      const std::vector<smt::UnorderedTermMap> & cex,
+      const std::unordered_map<std::string, std::string> & symbol_map = {});
 
   void dump_trace_to_file(const std::string & vcd_file_name) const;
   void debug_dump() const;

--- a/tests/encoders/inputs/btor2/invalid-smtlib-symbol.btor2
+++ b/tests/encoders/inputs/btor2/invalid-smtlib-symbol.btor2
@@ -1,0 +1,6 @@
+1 sort bitvec 1
+2 state 1 \[state\]
+3 input 1 #{input}
+4 and 1 2 3 *-and-*
+5 next 1 2 3
+6 bad 4

--- a/tests/encoders/test_btor2.cpp
+++ b/tests/encoders/test_btor2.cpp
@@ -103,6 +103,22 @@ TEST_P(Btor2UnitTests, InputProp)
   EXPECT_EQ(r, ProverResult::FALSE);
 }
 
+TEST_P(Btor2UnitTests, InvalidSmtlibSymbol)
+{
+  // test BTOR2 file with invalid SMT-LIB symbol
+  SmtSolver s = create_solver(GetParam());
+  s->set_opt("incremental", "true");
+  FunctionalTransitionSystem fts(s);
+  // PONO_SRC_DIR is a macro set using CMake PROJECT_SRC_DIR
+  string filename = STRFY(PONO_SRC_DIR);
+  filename += "/tests/encoders/inputs/btor2/invalid-smtlib-symbol.btor2";
+  BTOR2Encoder be(filename, fts);
+  Property p(fts.solver(), be.propvec()[0]);
+  Bmc bmc(p, fts, s);
+  ProverResult r = bmc.check_until(0);
+  ASSERT_NE(r, ProverResult::ERROR);
+}
+
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedSolverBtor2FileUnitTests,
     Btor2FileUnitTests,

--- a/utils/str_util.cpp
+++ b/utils/str_util.cpp
@@ -181,4 +181,12 @@ void add1(std::vector<char> & v)
 
 }  // namespace syntax_analysis
 
+const std::string & lookup_or_key(
+    const std::unordered_map<std::string, std::string> & map,
+    const std::string & key)
+{
+  auto it = map.find(key);
+  return (it != map.end() && !it->second.empty()) ? it->second : key;
+}
+
 }  // namespace pono

--- a/utils/str_util.h
+++ b/utils/str_util.h
@@ -75,4 +75,11 @@ void add1(std::vector<char> & v);
 
 }  // namespace syntax_analysis
 
+// loop up the key in the map
+// if found and value is non-empty, return the value
+// otherwise, return the key
+const std::string & lookup_or_key(
+    const std::unordered_map<std::string, std::string> & map,
+    const std::string & key);
+
 }  // namespace pono


### PR DESCRIPTION
This PR fixes #376.
Now Btor2 symbols are renamed internally into `{state,input,output,term}<id>`,
where `<id>` is the ID in Btor2.
A mapping between the internally-assigned names to the original names is stored,
and used to restore the signal names during witness printing.

This PR also closes #361 and #369, because they are no longer needed.
