### PR TITLE
Enable cvc5's interpolation

### DIFF
--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -48,8 +48,8 @@ IC3IA::IC3IA(const Property & p,
       conc_ts_(ts, to_prover_solver_),
       ia_(conc_ts_, ts_, unroller_),
       // only mathsat interpolator supported
-      interpolator_(create_interpolating_solver_for(
-          SolverEnum::MSAT_INTERPOLATOR, Engine::IC3IA_ENGINE)),
+      interpolator_(create_interpolating_solver_for(options_.smt_interpolator_,
+                                                    Engine::IC3IA_ENGINE)),
       to_interpolator_(interpolator_),
       to_solver_(solver_),
       longest_cex_length_(0)

--- a/engines/ic3sa.cpp
+++ b/engines/ic3sa.cpp
@@ -594,13 +594,10 @@ void IC3SA::initialize()
   super::initialize();
 
   if (options_.ic3sa_interp_) {
-#ifdef WITH_MSAT
-    interpolator_ = create_interpolating_solver_for(MSAT_INTERPOLATOR, engine_);
+    interpolator_ =
+        create_interpolating_solver_for(options_.smt_interpolator_, engine_);
     to_interpolator_ = std::make_unique<TermTranslator>(interpolator_);
     from_interpolator_ = std::make_unique<TermTranslator>(solver_);
-#else
-    throw PonoException("Running IC3SA with interpolation requires MathSAT.");
-#endif
   }
 
   // IC3SA assumes input variables are modeled as state variables

--- a/engines/interpolantmc.cpp
+++ b/engines/interpolantmc.cpp
@@ -31,8 +31,8 @@ InterpolantMC::InterpolantMC(const Property & p,
                              const SmtSolver & slv,
                              PonoOptions opt)
     : super(p, ts, slv, opt),
-      interpolator_(
-          create_interpolating_solver_for(opt.smt_solver_, Engine::INTERP)),
+      interpolator_(create_interpolating_solver_for(opt.smt_interpolator_,
+                                                    Engine::INTERP)),
       to_interpolator_(interpolator_),
       to_solver_(solver_)
 {

--- a/engines/interpolantmc.cpp
+++ b/engines/interpolantmc.cpp
@@ -31,9 +31,8 @@ InterpolantMC::InterpolantMC(const Property & p,
                              const SmtSolver & slv,
                              PonoOptions opt)
     : super(p, ts, slv, opt),
-      // only mathsat interpolator supported
-      interpolator_(create_interpolating_solver_for(
-          SolverEnum::MSAT_INTERPOLATOR, Engine::INTERP)),
+      interpolator_(
+          create_interpolating_solver_for(opt.smt_solver_, Engine::INTERP)),
       to_interpolator_(interpolator_),
       to_solver_(solver_)
 {

--- a/engines/mbic3.cpp
+++ b/engines/mbic3.cpp
@@ -74,6 +74,7 @@ ModelBasedIC3::ModelBasedIC3(const Property & p,
     : super(p, ts, slv, opt)
 {
   engine_ = Engine::MBIC3;
+  interpolator_enum_ = opt.smt_interpolator_;
 }
 
 IC3Formula ModelBasedIC3::get_model_ic3formula() const
@@ -364,7 +365,8 @@ void ModelBasedIC3::initialize()
 
   // only need interpolator infrastructure for mode 2 (interpolation)
   if (options_.mbic3_indgen_mode == 2) {
-    interpolator_ = create_interpolating_solver_for(MSAT_INTERPOLATOR, engine_);
+    interpolator_ =
+        create_interpolating_solver_for(interpolator_enum_, engine_);
     to_interpolator_ = std::make_unique<TermTranslator>(interpolator_);
     to_solver_ = std::make_unique<TermTranslator>(solver_);
 

--- a/engines/mbic3.h
+++ b/engines/mbic3.h
@@ -34,6 +34,7 @@ class ModelBasedIC3 : public IC3Base
  protected:
   // for mbic3_indgen_mode == 2
   // interpolant based generalization
+  smt::SolverEnum interpolator_enum_;
   smt::SmtSolver interpolator_;
   std::unique_ptr<smt::TermTranslator> to_interpolator_;
   std::unique_ptr<smt::TermTranslator> to_solver_;

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -818,9 +818,11 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
       }
     }
 
-    if (smt_solver_ != smt::MSAT && engine_ == Engine::INTERP) {
+    if (engine_ == Engine::INTERP
+        && !(smt_solver_ == smt::MSAT || smt_solver_ == smt::CVC5)) {
       throw PonoException(
-          "Interpolation engine can be only used with '--smt-solver msat'.");
+          "Interpolation engine can be only used with "
+          "'--smt-solver msat' or 'cvc5'.");
     }
 
     if (ceg_prophecy_arrays_ && smt_solver_ != smt::MSAT) {

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -51,6 +51,7 @@ enum optionIndex
   RESET_BND,
   CLK,
   SMT_SOLVER,
+  SMT_INTERPOLATOR,
   LOGGING_SMT_SOLVER,
   PRINTING_SMT_SOLVER,
   NO_IC3_PREGEN,
@@ -190,7 +191,20 @@ const option::Descriptor usage[] = {
     "",
     "smt-solver",
     Arg::NonEmpty,
-    "  --smt-solver \tSMT Solver to use: btor, bzla, msat, yices2, or cvc5." },
+    "  --smt-solver \tSMT Solver to use: btor, bzla, msat, yices2, or cvc5. "
+    "(default: bzla)" },
+  { SMT_INTERPOLATOR,
+    0,
+    "",
+    "smt-interpolator",
+    Arg::NonEmpty,
+    "  --smt-interpolator \tSMT Solver used for interpolation: msat or cvc5. "
+#ifdef WITH_MSAT
+    "(default: msat)"
+#else
+    "(default: cvc5)"
+#endif
+  },
   { LOGGING_SMT_SOLVER,
     0,
     "",
@@ -692,6 +706,18 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
           }
           break;
         }
+        case SMT_INTERPOLATOR: {
+          if (opt.arg == std::string("cvc5")) {
+            smt_interpolator_ = smt::CVC5_INTERPOLATOR;
+          } else if (opt.arg == std::string("msat")) {
+            smt_interpolator_ = smt::MSAT_INTERPOLATOR;
+          } else {
+            throw PonoException("Unknown interpolator: "
+                                + std::string(opt.arg));
+            break;
+          }
+          break;
+        }
         case LOGGING_SMT_SOLVER: logging_smt_solver_ = true; break;
         case PRINTING_SMT_SOLVER: printing_smt_solver_ = true; break;
         case WITNESS: witness_ = true; break;
@@ -816,13 +842,6 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
           // which aborts the parse with an error
           break;
       }
-    }
-
-    if (engine_ == Engine::INTERP
-        && !(smt_solver_ == smt::MSAT || smt_solver_ == smt::CVC5)) {
-      throw PonoException(
-          "Interpolation engine can be only used with "
-          "'--smt-solver msat' or 'cvc5'.");
     }
 
     if (ceg_prophecy_arrays_ && smt_solver_ != smt::MSAT) {

--- a/options/options.h
+++ b/options/options.h
@@ -96,6 +96,7 @@ class PonoOptions
         reset_bnd_(default_reset_bnd_),
         random_seed_(default_random_seed),
         smt_solver_(default_smt_solver_),
+        smt_interpolator_(default_smt_interpolator_),
         logging_smt_solver_(default_logging_smt_solver_),
         printing_smt_solver_(default_printing_smt_solver_),
         static_coi_(default_static_coi_),
@@ -157,7 +158,7 @@ class PonoOptions
   {
   }
 
-  ~PonoOptions() {};
+  ~PonoOptions(){};
 
   /** Parse and set options given argc and argv from main
    *  @param argc
@@ -189,7 +190,8 @@ class PonoOptions
   size_t reset_bnd_;
   std::string clock_name_;
   std::string filename_;
-  smt::SolverEnum smt_solver_;  ///< underlying smt solver
+  smt::SolverEnum smt_solver_;        ///< underlying smt solver
+  smt::SolverEnum smt_interpolator_;  ///< smt solver for interpolation
   bool logging_smt_solver_;
   bool printing_smt_solver_;
   bool static_coi_;
@@ -318,6 +320,12 @@ class PonoOptions
   // TODO distinguish when solver is not set and choose a
   //      good solver for the provided engine automatically
   static const smt::SolverEnum default_smt_solver_ = smt::BZLA;
+  static const smt::SolverEnum default_smt_interpolator_ =
+#ifdef WITH_MSAT
+      smt::MSAT;
+#else
+      smt::CVC5;
+#endif
   static const bool default_logging_smt_solver_ = false;
   static const bool default_printing_smt_solver_ = false;
   static const bool default_ic3_pregen_ = true;

--- a/smt/available_solvers.cpp
+++ b/smt/available_solvers.cpp
@@ -231,6 +231,9 @@ SmtSolver create_interpolating_solver_for(SolverEnum se, Engine e)
 {
   if (ic3_variants().find(e) == ic3_variants().end()) {
     return create_interpolating_solver(se);
+  } else if (se != MSAT) {
+    throw SmtException(
+        "Running IC3-based engine with interpolation requires MathSAT.");
   }
 
   switch (se) {

--- a/smt/available_solvers.cpp
+++ b/smt/available_solvers.cpp
@@ -229,11 +229,8 @@ SmtSolver create_interpolating_solver(SolverEnum se)
 
 SmtSolver create_interpolating_solver_for(SolverEnum se, Engine e)
 {
-  if (ic3_variants().find(e) == ic3_variants().end()) {
+  if (ic3_variants().find(e) == ic3_variants().end() || se != MSAT) {
     return create_interpolating_solver(se);
-  } else if (se != MSAT) {
-    throw SmtException(
-        "Running IC3-based engine with interpolation requires MathSAT.");
   }
 
   switch (se) {

--- a/smt/available_solvers.cpp
+++ b/smt/available_solvers.cpp
@@ -206,6 +206,12 @@ SmtSolver create_reducer_for(SolverEnum se, Engine e, bool logging)
 SmtSolver create_interpolating_solver(SolverEnum se)
 {
   switch (se) {
+    case CVC5:
+    case CVC5_INTERPOLATOR: {
+      return Cvc5SolverFactory::create_interpolating_solver();
+      break;
+      ;
+    }
 #if WITH_MSAT
     // for convenience -- accept any MSAT SolverEnum
     case MSAT:


### PR DESCRIPTION
Smt-Switch already supports cvc5's interpolation API.
This PR simply enables this in Pono.