### PR TITLE
Adhere to project's clang-format setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ on: [push, pull_request]
 name: CI
 
 jobs:
-  check-format:
+  format-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
 
-    name: ${{ matrix.os }}
+    name: ${{ matrix.os }}-build
     runs-on: ${{ matrix.os}}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
 
       - name: Check format using clang-format
         run: |
-          find . -type d -name "contrib" -prune -or -type f \( -name '*.h' -or -name '*.cpp' \) -print | \
-            xargs clang-format --dry-run -Werror --style=file
+          find . -type d -name "contrib" -prune -or -type f \( -name '*.h' -or -name '*.cpp' \) -print \
+          | xargs clang-format --dry-run -Werror --style=file
 
   build:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,16 @@ on: [push, pull_request]
 name: CI
 
 jobs:
+  check-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check format using clang-format
+        run: |
+          find . -type d -name "contrib" -prune -or -type f \( -name '*.h' -or -name '*.cpp' \) -print | \
+            xargs clang-format --dry-run -Werror --style=file
+
   build:
     strategy:
       matrix:

--- a/core/prop.h
+++ b/core/prop.h
@@ -25,9 +25,9 @@ class Property
 {
  public:
   Property(const smt::SmtSolver & s, const smt::Term & p, std::string name = "")
-      : solver_(s), prop_(p), name_(name) {};
+      : solver_(s), prop_(p), name_(name){};
 
-  ~Property() {};
+  ~Property(){};
 
   const smt::Term & prop() const { return prop_; }
 

--- a/core/ts.h
+++ b/core/ts.h
@@ -67,7 +67,7 @@ class TransitionSystem
    */
   TransitionSystem(const TransitionSystem & other_ts, smt::TermTranslator & tt);
 
-  virtual ~TransitionSystem() {};
+  virtual ~TransitionSystem(){};
 
   /** Equality comparison between TransitionSystems
    *  compares each member variable

--- a/engines/cegar.h
+++ b/engines/cegar.h
@@ -35,7 +35,7 @@ class CEGAR : public Prover_T
   {
   }
 
-  virtual ~CEGAR() {};
+  virtual ~CEGAR(){};
 
  protected:
   /** Abstract the transition system -- usually only performed once

--- a/options/options.h
+++ b/options/options.h
@@ -157,7 +157,7 @@ class PonoOptions
   {
   }
 
-  ~PonoOptions() {};
+  ~PonoOptions(){};
 
   /** Parse and set options given argc and argv from main
    *  @param argc

--- a/pono.cpp
+++ b/pono.cpp
@@ -80,7 +80,6 @@ ProverResult check_prop(PonoOptions pono_options,
     prop = ts.solver()->make_term(Implies, reset_done, prop);
   }
 
-
   if (pono_options.static_coi_) {
     /* Compute the set of state/input variables related to the
        bad-state property. Based on that information, rebuild the
@@ -136,21 +135,18 @@ ProverResult check_prop(PonoOptions pono_options,
   //       model checker runs prove unbounded) or possibly, have a command line
   //       flag to pick between the two
   ProverResult r;
-  if (pono_options.engine_ == MSAT_IC3IA)
-  {
+  if (pono_options.engine_ == MSAT_IC3IA) {
     // HACK MSAT_IC3IA does not support check_until
     r = prover->prove();
-  }
-  else
-  {
+  } else {
     r = prover->check_until(pono_options.bound_ + has_monitor);
   }
 
   if (r == FALSE && pono_options.witness_) {
     bool success = prover->witness(cex);
     if (has_monitor) {
-      // Witness will always have at least one element, because the monitor is constrained
-      // to start true.
+      // Witness will always have at least one element, because the monitor is
+      // constrained to start true.
       cex.pop_back();
     }
     if (!success) {
@@ -414,8 +410,8 @@ int main(int argc, char ** argv)
   if (pono_options.print_wall_time_) {
     auto end_time_stamp = timestamp();
     auto elapsed_time = timestamp_diff(begin_time_stamp, end_time_stamp);
-    std:cout << "Pono wall clock time (s): " <<
-      time_duration_to_sec_string(elapsed_time) << std::endl;
+    std::cout << "Pono wall clock time (s): "
+              << time_duration_to_sec_string(elapsed_time) << std::endl;
   }
 
   return res;

--- a/refiners/axiom_enumerator.h
+++ b/refiners/axiom_enumerator.h
@@ -56,7 +56,7 @@ class AxiomEnumerator
   {
   }
 
-  virtual ~AxiomEnumerator() {};
+  virtual ~AxiomEnumerator(){};
 
   virtual void initialize() = 0;
 

--- a/utils/sygus_predicate_constructor.cpp
+++ b/utils/sygus_predicate_constructor.cpp
@@ -120,8 +120,8 @@ void PredConstructor::TermsDumping() const
     auto nt_size = terms_consts.terms.size();
     auto nc_size = terms_consts.constants.size();
 
-    std::cout << "[Width = " << width << "] "
-              << "[#Term = " << nt_size << ", #Consts = " << nc_size << "]\n";
+    std::cout << "[Width = " << width << "] " << "[#Term = " << nt_size
+              << ", #Consts = " << nc_size << "]\n";
 
     std::cout << "  C : ";
 #if TERM_TABLE_DEBUG_LVL < 2


### PR DESCRIPTION
This PR follows up #374, fixes some missing formatting issues,
and adds a CI job to ensure new commits adhere to the project's clang-format setting.