### PR TITLE
Add Dockerfile for building container image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,24 @@
+name: Docker Build & Publish to GHCR
+on: push
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ github.event.repository.name }}:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,11 +1,11 @@
-name: Docker Build & Publish to GHCR
+name: Docker
 on: push
 
 env:
   REGISTRY: ghcr.io
 
 jobs:
-  docker:
+   build-and-publish-to-ghcr:
     runs-on: ubuntu-latest
     steps:
       - name: Log in to GHCR
@@ -14,7 +14,8 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build and push

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,9 @@
 name: Docker
-on: push
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:  # allow manual trigger
 
 env:
   REGISTRY: ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN ./contrib/setup-bison.sh
 RUN ./contrib/setup-flex.sh
 RUN ./contrib/setup-smt-switch.sh
 RUN ./contrib/setup-btor2tools.sh
-RUN ./configure.sh
+RUN ./configure.sh --static
 RUN cd build/ && \
     make -j$(nproc)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:24.04
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY . /app/pono/
+WORKDIR /app/pono/
+
+RUN apt-get update
+RUN apt-get upgrade -y
+RUN apt-get install -y \
+        build-essential \
+        cmake \
+        curl \
+        git \
+        libgmp-dev \
+        m4 \
+        meson \
+        ninja-build \
+        pkg-config \
+        python3 \
+        python3-pyparsing
+RUN apt-get autoremove --purge
+RUN apt-get clean -y
+RUN ./contrib/setup-bison.sh
+RUN ./contrib/setup-flex.sh
+RUN ./contrib/setup-smt-switch.sh
+RUN ./contrib/setup-btor2tools.sh
+RUN ./configure.sh
+RUN cd build/ && \
+    make -j$(nproc)
+
+RUN ln -s /app/pono/build/pono /usr/local/bin/pono
+ENTRYPOINT ["/usr/local/bin/pono"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,16 +17,26 @@ RUN apt-get install -y \
         ninja-build \
         pkg-config \
         python3 \
-        python3-pyparsing
+        python3-pyparsing \
+        wget
 RUN apt-get autoremove --purge
 RUN apt-get clean -y
 RUN ./contrib/setup-bison.sh
 RUN ./contrib/setup-flex.sh
-RUN ./contrib/setup-smt-switch.sh
 RUN ./contrib/setup-btor2tools.sh
+
+## To setup MathSAT dependencies, uncomment the following line:
+# RUN ./ci-scripts/setup-msat.sh -y
+## Then, add --with-msat to the command below
+RUN ./contrib/setup-smt-switch.sh
+
+## To setup IC3ia dependencies, uncomment the following line:
+# RUN ./contrib/setup-ic3ia.sh
+## To build Pono with MathSAT and IC3ia,
+## add --with-msat and --with-msat-ic3ia to the command below, respectively
 RUN ./configure.sh --static
-RUN cd build/ && \
-    make -j$(nproc)
+
+RUN cd build/ && make -j$(nproc)
 
 RUN ln -s /app/pono/build/pono /usr/local/bin/pono
 ENTRYPOINT ["/usr/local/bin/pono"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-[![CI](https://github.com/upscale-project/pono/actions/workflows/ci.yml/badge.svg)](https://github.com/upscale-project/pono/actions/workflows/ci.yml)
+[![CI](https://github.com/stanford-centaur/pono/actions/workflows/ci.yml/badge.svg)](https://github.com/stanford-centaur/pono/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://github.com/stanford-centaur/pono/blob/main/LICENSE)
 
 # Pono: A Flexible and Extensible SMT-Based Model Checker
+
 Pono is a performant, adaptable, and extensible SMT-based model checker implemented in C++. It leverages [Smt-Switch](https://github.com/stanford-centaur/smt-switch), a generic C++ API for SMT solving. Pono was developed as the next
 generation of [CoSA](https://github.com/cristian-mattarei/CoSA) and thus was originally named _cosa2_.
 
@@ -23,7 +25,7 @@ Pono was awarded the Oski Award under its original name _cosa2_ at [HWMCC'19](ht
   * If you don't have bison and flex installed globally, run `./contrib/setup-bison.sh` and `./contrib/setup-flex.sh`
   * Even if you do have bison, you might get errors about not being able to load `-ly`. In such a case, run the bison setup script.
 * Run `./contrib/setup-smt-switch.sh` -- it will build smt-switch with Bitwuzla
-  * [optional] to build with MathSAT (required for interpolant-based model checking) you need to obtain the libraries yourself
+  * [optional] to build with MathSAT (required for interpolation-based model checking) you need to obtain the libraries yourself
     * note that MathSAT is under a custom non-BSD compliant license and you must assume all responsibility for meeting the conditions
     * download the solver from https://mathsat.fbk.eu/download.html, unpack it and rename the directory to `./deps/mathsat`
     * then add the `--with-msat` flag to the `setup-smt-switch.sh` command.
@@ -65,23 +67,28 @@ gperftools is licensed under a BSD 3-clause license, see
 ## Existing code
 
 ### Transition Systems
+
 There are two Transition System interfaces:
+
 * FunctionalTransitionSystem in fts.*
 * TransitionSystem in rts.*
 
-
 ### Smt-Switch
+
 [Smt-switch](https://github.com/stanford-centaur/smt-switch) is a C++ solver-agnostic API for SMT solvers. The main thing to remember is that everything is a pointer. Objects might be "typedef-ed" with `using` statements, but they're still `shared_ptr`s. Thus, when using a solver or a term, you need to use `->` accesses.
 
 For more information, see the example usage in the [smt-switch tests](https://github.com/stanford-centaur/smt-switch/tree/master/tests/btor).
 Other useful files to visit include:
+
 * `smt-switch/include/solver.h`: this is the main interface you will be using
 * `smt-switch/include/ops.h`: this contains all the ops you might need
   * Note: create indexed ops like `Op(Extract, 7, 4)`
 
 ## Python bindings
+
 To build the `pono` python bindings, first make sure that you have [Cython](https://cython.org/) version >= 0.29 installed. Then ensure that `smt-switch` and its python bindings are installed. Finally, you can configure with `./configure.sh --python` and then build normally. The sequence of commands would be as follows:
-```
+
+```bash
 # Optional recommended step: start a python virtualenv
 # If you install in the virtualenv, you will need to activate it each time before using pono
 # and deactivate the virtualenv with: deactivate

--- a/README.md
+++ b/README.md
@@ -41,6 +41,27 @@ Pono was awarded the Oski Award under its original name _cosa2_ at [HWMCC'19](ht
 * Please see the [README of smt-switch](https://github.com/stanford-centaur/smt-switch#dependencies) for required dependencies.
 * Note to Arch Linux users: building Pono will fail if the static library of [GMP](https://gmplib.org/), which is required by [cvc5](https://github.com/cvc5/cvc5/blob/main/INSTALL.rst), is not installed on your system. You can fix it by installing `libgmp-static` from [AUR](https://aur.archlinux.org/packages/libgmp-static).
 
+### Docker
+
+We provide a Dockerfile for building a container image with Pono and all its dependencies.
+To build the image locally, run:
+
+```bash
+docker build -t pono .
+```
+
+(You can replace `docker` with `podman` if you prefer a Docker-compatible alternative.)
+
+Note that the Docker image does not include the MathSAT backend due to licensing restrictions.
+If you need MathSAT support, please modify the Dockerfile manually to include it.
+
+For your convenience, we publish the image built from the latest commit of main branch to GitHub Container Registry.
+You can pull the image with:
+
+```bash
+docker pull ghcr.io/stanford-centaur/pono:latest
+```
+
 ### Profiling
 
 We link against the [gperftools library](https://github.com/gperftools/gperftools)


### PR DESCRIPTION
This PR introduces a Dockerfile for building the project in a containerized environment.
Additionally, a GitHub Actions workflow is added to automatically build the image on each push to `main` and publish it to GitHub Container Registry (GHCR).
This allows users to run Pono easily across platforms without needing to compile it themselves.

To-dos:

- [x] Make the registry public
- [x] Switch to static build after #390 is resolved