### PR TITLE
Add git metadata to container image's label

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,9 @@ jobs:
    build-and-publish-to-ghcr:
     runs-on: ubuntu-latest
     steps:
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -27,3 +30,4 @@ jobs:
         with:
           push: true
           tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ github.event.repository.name }}:latest
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR follows up on #391 by adding metadata to the container image.
Users can now check the commit from which the image was built using:

```bash
docker image inspect ghcr.io/stanford-centaur/pono:latest --format='{{index .Config.Labels "org.opencontainers.image.revision"}}'
```