### PR TITLE
Clean up preprocessor directives and try-catch related to MathSAT

### DIFF
--- a/engines/interpolantmc.cpp
+++ b/engines/interpolantmc.cpp
@@ -49,12 +49,12 @@ void InterpolantMC::initialize()
 
   super::initialize();
 
-  reset_assertions(interpolator_);
+  interpolator_->reset_assertions();
 
   // symbols are already created in solver
   // need to add symbols at time 1 to cache
-  // (only time 1 because Craig Interpolant has to share symbols between A and
-  // B)
+  // (only at time 1 because Craig Interpolation has to share symbols
+  // between A and B)
   UnorderedTermMap & cache = to_solver_.get_cache();
   Term tmp1;
   for (const auto & s : ts_.statevars()) {
@@ -156,7 +156,7 @@ bool InterpolantMC::step(int i)
       // found a concrete counter example
       // replay it in the solver with model generation
       concrete_cex_ = true;
-      reset_assertions(solver_);
+      solver_->reset_assertions();
 
       Term solver_trans = solver_->make_term(And, transA_, transB_);
       solver_->assert_formula(solver_->make_term(
@@ -185,7 +185,7 @@ bool InterpolantMC::step(int i)
 
 bool InterpolantMC::step_0()
 {
-  reset_assertions(solver_);
+  solver_->reset_assertions();
   solver_->assert_formula(init0_);
   solver_->assert_formula(unroller_.at_time(bad_, 0));
 
@@ -198,22 +198,9 @@ bool InterpolantMC::step_0()
   return false;
 }
 
-void InterpolantMC::reset_assertions(SmtSolver & s)
-{
-  // reset assertions is not supported by all solvers
-  // but MathSAT is the only supported solver that can do interpolation
-  // so this should be safe
-  try {
-    s->reset_assertions();
-  }
-  catch (NotImplementedException & e) {
-    throw PonoException("Got unexpected solver in InterpolantMC.");
-  }
-}
-
 bool InterpolantMC::check_entail(const Term & p, const Term & q)
 {
-  reset_assertions(solver_);
+  solver_->reset_assertions();
   solver_->assert_formula(
       solver_->make_term(And, p, solver_->make_term(Not, q)));
   Result r = solver_->check_sat();

--- a/smt/available_solvers.cpp
+++ b/smt/available_solvers.cpp
@@ -257,8 +257,9 @@ SmtSolver create_interpolating_solver_for(SolverEnum se, Engine e)
 }
 
 const std::vector<SolverEnum> itp_enums({
+    CVC5_INTERPOLATOR,
 #if WITH_MSAT
-    MSAT_INTERPOLATOR
+    MSAT_INTERPOLATOR,
 #endif
 });
 

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -134,8 +134,8 @@ TEST_P(UtilsEngineUnitTests, MakeProver)
   SolverEnum se = get<0>(GetParam());
   Engine eng = get<1>(GetParam());
 
-  if (eng == INTERP && se != MSAT) {
-    // skip interpolation unless the solver is MathSAT
+  if ((eng == INTERP || eng == IC3IA_ENGINE) && se != MSAT) {
+    // skip interpolation and IC3ia unless the solver is MathSAT
     return;
   }
 

--- a/utils/make_provers.cpp
+++ b/utils/make_provers.cpp
@@ -41,11 +41,7 @@ namespace pono {
 
 vector<Engine> all_engines()
 {
-#ifdef WITH_MSAT
   return { BMC, BMC_SP, KIND, MBIC3, INTERP, IC3IA_ENGINE, IC3SA_ENGINE };
-#else
-  return { BMC, BMC_SP, KIND, MBIC3, IC3SA_ENGINE };
-#endif
 }
 
 shared_ptr<Prover> make_prover(Engine e,
@@ -61,23 +57,13 @@ shared_ptr<Prover> make_prover(Engine e,
   } else if (e == KIND) {
     return make_shared<KInduction>(p, ts, slv, opts);
   } else if (e == INTERP) {
-#ifdef WITH_MSAT
     return make_shared<InterpolantMC>(p, ts, slv, opts);
-#else
-    throw PonoException(
-        "Interpolant-based modelchecking requires an interpolator");
-#endif
   } else if (e == MBIC3) {
     return make_shared<ModelBasedIC3>(p, ts, slv, opts);
   } else if (e == IC3_BITS) {
     return make_shared<IC3Bits>(p, ts, slv, opts);
   } else if (e == IC3IA_ENGINE) {
-#ifdef WITH_MSAT
     return make_shared<IC3IA>(p, ts, slv, opts);
-#else
-    throw PonoException(
-        "IC3IA uses MathSAT for interpolants, but not built with MathSAT");
-#endif
 #ifdef WITH_MSAT_IC3IA
   } else if (e == MSAT_IC3IA) {
     return make_shared<MsatIC3IA>(p, ts, slv, opts);
@@ -108,12 +94,7 @@ shared_ptr<Prover> make_ceg_proph_prover(Engine e,
   } else if (e == MBIC3) {
     return std::make_shared<CegProphecyArrays<ModelBasedIC3>>(p, ts, slv, opts);
   } else if (e == IC3IA_ENGINE) {
-#ifdef WITH_MSAT
     return std::make_shared<CegProphecyArrays<IC3IA>>(p, ts, slv, opts);
-#else
-    throw PonoException(
-        "IC3IA uses MathSAT for interpolants, but not built with MathSAT");
-#endif
   }
 #ifdef WITH_MSAT_IC3IA
   else if (e == MSAT_IC3IA) {


### PR DESCRIPTION
Since #385, MathSAT is not strictly required to run engines that use interpolation.
This PR removes outdated preprocessor directives and a try-catch block.