### PR TITLE
Store failing test log in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,9 +93,24 @@ jobs:
           make -j
 
       - name: Test C++
+        id: test-cpp
+        continue-on-error: true
         run: |
           cd build
           make check
+
+      - name: Upload failing test log
+        if: steps.test-cpp.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: failing-test-log
+          path: build/tests/Testing/Temporary/LastTest.log
+      
+      - name: Fail pipeline due to C++ test failure
+        if: steps.test-cpp.outcome == 'failure'
+        run: |
+          echo "C++ tests failed. Inspect the artifact for details."
+          exit 1
 
       - name: Install Python Bindings
         run: python3 -m pip install -e ./build/python[test,pysmt]


### PR DESCRIPTION
This PR improves the CI workflow by preserving test logs when C++ tests fail,
making debugging failing tests, especially the cross-platform ones, much easier.
An example: https://github.com/stanford-centaur/pono/actions/runs/14630838712

The artifacts will be automatically deleted after the retention period.