### PR TITLE
Add missing header

### DIFF
--- a/tests/encoders/test_btor2.cpp
+++ b/tests/encoders/test_btor2.cpp
@@ -1,6 +1,6 @@
+#include <algorithm>
 #include <string>
 #include <tuple>
-#include <vector>
 
 #include "core/fts.h"
 #include "engines/bmc.h"


### PR DESCRIPTION
Compiling `tests/encoders/test_btor2.cpp` fails on my computer (with GCC 14.2.1) with the following error:

```
/mnt/data/repos/pono/tests/encoders/test_btor2.cpp: In member function ‘virtual void pono_tests::Btor2FileUnitTests_Encode_Test::TestBody()’:
/mnt/data/repos/pono/tests/encoders/test_btor2.cpp:50:7: error: ‘count_if’ was not declared in this scope
   50 |       count_if(free_vars.begin(), free_vars.end(), [&fts](const Term & v) {
      |       ^~~~~~~~
```

This is because `std::count_if` is in the `<algorithm>` standard library header, which is not included in this file (see https://en.cppreference.com/w/cpp/algorithm/count).