### PR TITLE
Cast init term to bit-vector

### DIFF
--- a/frontends/btor2_encoder.cpp
+++ b/frontends/btor2_encoder.cpp
@@ -377,9 +377,13 @@ void BTOR2Encoder::parse(const std::string filename)
       Term inbt2_iteq;
 
       if (linesort->get_sort_kind() == BV) {
-        inbt2_iteq = solver_->make_term(Equal, termargs);
+        // state variables are always bitvectors
+        // so we only need to make sure the init term is a bitvector
+        inbt2_iteq =
+            solver_->make_term(Equal, termargs[0], bool_to_bv(termargs[1]));
       } else if (linesort->get_sort_kind() == ARRAY) {
         if (termargs[1]->get_sort()->get_sort_kind() == BV) {
+          // initialize the array state with a bitvector constant
           inbt2_iteq = solver_->make_term(
               Equal, termargs[0], solver_->make_term(termargs[1], linesort));
         } else {

--- a/tests/encoders/inputs/btor2/bool-init.btor2
+++ b/tests/encoders/inputs/btor2/bool-init.btor2
@@ -1,0 +1,7 @@
+1 sort bitvec 1
+2 const 1 1
+3 ult 1 2 2
+4 state 1
+5 init 1 4 3
+6 next 1 4 2
+7 bad 4

--- a/tests/encoders/test_btor2.cpp
+++ b/tests/encoders/test_btor2.cpp
@@ -119,6 +119,22 @@ TEST_P(Btor2UnitTests, InvalidSmtlibSymbol)
   ASSERT_NE(r, ProverResult::ERROR);
 }
 
+TEST_P(Btor2UnitTests, InitStateWithBool)
+{
+  // test BTOR2 file with invalid SMT-LIB symbol
+  SmtSolver s = create_solver(GetParam());
+  s->set_opt("incremental", "true");
+  FunctionalTransitionSystem fts(s);
+  // PONO_SRC_DIR is a macro set using CMake PROJECT_SRC_DIR
+  string filename = STRFY(PONO_SRC_DIR);
+  filename += "/tests/encoders/inputs/btor2/bool-init.btor2";
+  BTOR2Encoder be(filename, fts);
+  Property p(fts.solver(), be.propvec()[0]);
+  Bmc bmc(p, fts, s);
+  ProverResult r = bmc.check_until(0);
+  ASSERT_NE(r, ProverResult::ERROR);
+}
+
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedSolverBtor2FileUnitTests,
     Btor2FileUnitTests,


### PR DESCRIPTION
In Btor2, a bit-vector state can be initialized using a term that is the result of some operation.
However, if the initialization term is of boolean type, this can lead to issues during term construction due to the mismatching types.
To avoid this, the initialization term should always be cast to a bit-vector.