### PR TITLE
Refactor(UnsignedConvert): `atoi` to `stoul`

### DIFF
--- a/options/options.cpp
+++ b/options/options.cpp
@@ -751,9 +751,9 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case ENGINE: engine_ = to_engine(opt.arg); break;
         case BOUND:
           bound_ = strtoul(opt.arg, NULL, 10);
-          if (bound_ == UINT_MAX) {
+          if (bound_ == INT_MAX) {
             throw PonoException("--bound must be less than "
-                                + std::to_string(UINT_MAX) + ".");
+                                + std::to_string(INT_MAX) + ".");
           }
           break;
         case PROP: prop_idx_ = strtoul(opt.arg, NULL, 10); break;

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -750,15 +750,15 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
           // not possible, because handled further above and exits the program
         case ENGINE: engine_ = to_engine(opt.arg); break;
         case BOUND:
-          bound_ = atoi(opt.arg);
-          if (bound_ == INT_MAX) {
+          bound_ = strtoul(opt.arg, NULL, 10);
+          if (bound_ == UINT_MAX) {
             throw PonoException("--bound must be less than "
-                                + std::to_string(INT_MAX) + ".");
+                                + std::to_string(UINT_MAX) + ".");
           }
           break;
-        case PROP: prop_idx_ = atoi(opt.arg); break;
-        case VERBOSITY: verbosity_ = atoi(opt.arg); break;
-        case RANDOM_SEED: random_seed_ = atoi(opt.arg); break;
+        case PROP: prop_idx_ = strtoul(opt.arg, NULL, 10); break;
+        case VERBOSITY: verbosity_ = strtoul(opt.arg, NULL, 10); break;
+        case RANDOM_SEED: random_seed_ = strtoul(opt.arg, NULL, 10); break;
         case VCDNAME:
           vcd_name_ = opt.arg;
           witness_ = true;  // implicitly enabling witness
@@ -803,13 +803,15 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case SHOW_INVAR: show_invar_ = true; break;
         case CHECK_INVAR: check_invar_ = true; break;
         case RESET: reset_name_ = opt.arg; break;
-        case RESET_BND: reset_bnd_ = atoi(opt.arg); break;
+        case RESET_BND: reset_bnd_ = strtoul(opt.arg, NULL, 10); break;
         case CLK: clock_name_ = opt.arg; break;
         case NO_IC3_PREGEN: ic3_pregen_ = false; break;
         case NO_IC3_INDGEN: ic3_indgen_ = false; break;
-        case IC3_GEN_MAX_ITER: ic3_gen_max_iter_ = atoi(opt.arg); break;
+        case IC3_GEN_MAX_ITER:
+          ic3_gen_max_iter_ = strtoul(opt.arg, NULL, 10);
+          break;
         case MBIC3_INDGEN_MODE:
-          mbic3_indgen_mode = atoi(opt.arg);
+          mbic3_indgen_mode = strtoul(opt.arg, NULL, 10);
           if (!(mbic3_indgen_mode >= 0 && mbic3_indgen_mode <= 2))
             throw PonoException(
                 "--ic3-indgen-mode value must be between 0 and 2.");
@@ -839,19 +841,23 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
           break;
         case CEGP_FORCE_RESTART: cegp_force_restart_ = true; break;
         case CEGP_ABS_VALS: cegp_abs_vals_ = true; break;
-        case CEGP_ABS_VALS_CUTOFF: cegp_abs_vals_cutoff_ = atoi(opt.arg); break;
+        case CEGP_ABS_VALS_CUTOFF:
+          cegp_abs_vals_cutoff_ = strtoul(opt.arg, NULL, 10);
+          break;
         case CEGP_STRONG_ABSTRACTION: cegp_strong_abstraction_ = true; break;
         case CEG_BV_ARITH: ceg_bv_arith_ = true; break;
-        case CEG_BV_ARITH_MIN_BW: ceg_bv_arith_min_bw_ = atoi(opt.arg); break;
+        case CEG_BV_ARITH_MIN_BW:
+          ceg_bv_arith_min_bw_ = strtoul(opt.arg, NULL, 10);
+          break;
         case PROMOTE_INPUTVARS: promote_inputvars_ = true; break;
         case SYGUS_OP_LVL:
-          sygus_use_operator_abstraction_ = atoi(opt.arg);
+          sygus_use_operator_abstraction_ = strtoul(opt.arg, NULL, 10);
           break;
         case SYGUS_TERM_MODE:
-          sygus_term_mode_ = SyGuSTermMode(atoi(opt.arg));
+          sygus_term_mode_ = SyGuSTermMode(strtoul(opt.arg, NULL, 10));
           break;
         case IC3SA_INITIAL_TERMS_LVL: {
-          ic3sa_initial_terms_lvl_ = atoi(opt.arg);
+          ic3sa_initial_terms_lvl_ = strtoul(opt.arg, NULL, 10);
           if (ic3sa_initial_terms_lvl_ > 4) {
             throw PonoException(
                 "--ic3sa-initial-terms-lvl must be an integer in [0, 4]");
@@ -860,9 +866,11 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         }
         case IC3SA_INTERP: ic3sa_interp_ = true; break;
         case PRINT_WALL_TIME: print_wall_time_ = true; break;
-        case BMC_BOUND_START: bmc_bound_start_ = atoi(opt.arg); break;
+        case BMC_BOUND_START:
+          bmc_bound_start_ = strtoul(opt.arg, NULL, 10);
+          break;
         case BMC_BOUND_STEP:
-          bmc_bound_step_ = atoi(opt.arg);
+          bmc_bound_step_ = strtoul(opt.arg, NULL, 10);
           if (bmc_bound_step_ == 0)
             throw PonoException("--bmc-bound-step must be greater than 0");
           break;
@@ -912,7 +920,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
           break;
         case KIND_ONE_TIME_BASE_CHECK: kind_one_time_base_check_ = true; break;
         case KIND_BOUND_STEP:
-          kind_bound_step_ = atoi(opt.arg);
+          kind_bound_step_ = strtoul(opt.arg, NULL, 10);
           if (kind_bound_step_ == 0)
             throw PonoException("--kind-bound-step must be greater than 0");
           break;

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -750,15 +750,15 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
           // not possible, because handled further above and exits the program
         case ENGINE: engine_ = to_engine(opt.arg); break;
         case BOUND:
-          bound_ = std::stoul(opt.arg, NULL, 10);
+          bound_ = std::stoul(opt.arg);
           if (bound_ >= INT_MAX) {
             throw PonoException("--bound must be less than "
                                 + std::to_string(INT_MAX) + ".");
           }
           break;
-        case PROP: prop_idx_ = std::stoul(opt.arg, NULL, 10); break;
-        case VERBOSITY: verbosity_ = std::stoul(opt.arg, NULL, 10); break;
-        case RANDOM_SEED: random_seed_ = std::stoul(opt.arg, NULL, 10); break;
+        case PROP: prop_idx_ = std::stoul(opt.arg); break;
+        case VERBOSITY: verbosity_ = std::stoul(opt.arg); break;
+        case RANDOM_SEED: random_seed_ = std::stoul(opt.arg); break;
         case VCDNAME:
           vcd_name_ = opt.arg;
           witness_ = true;  // implicitly enabling witness
@@ -803,15 +803,15 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case SHOW_INVAR: show_invar_ = true; break;
         case CHECK_INVAR: check_invar_ = true; break;
         case RESET: reset_name_ = opt.arg; break;
-        case RESET_BND: reset_bnd_ = std::stoul(opt.arg, NULL, 10); break;
+        case RESET_BND: reset_bnd_ = std::stoul(opt.arg); break;
         case CLK: clock_name_ = opt.arg; break;
         case NO_IC3_PREGEN: ic3_pregen_ = false; break;
         case NO_IC3_INDGEN: ic3_indgen_ = false; break;
         case IC3_GEN_MAX_ITER:
-          ic3_gen_max_iter_ = std::stoul(opt.arg, NULL, 10);
+          ic3_gen_max_iter_ = std::stoul(opt.arg);
           break;
         case MBIC3_INDGEN_MODE:
-          mbic3_indgen_mode = std::stoul(opt.arg, NULL, 10);
+          mbic3_indgen_mode = std::stoul(opt.arg);
           if (!(mbic3_indgen_mode >= 0 && mbic3_indgen_mode <= 2))
             throw PonoException(
                 "--ic3-indgen-mode value must be between 0 and 2.");
@@ -842,22 +842,22 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case CEGP_FORCE_RESTART: cegp_force_restart_ = true; break;
         case CEGP_ABS_VALS: cegp_abs_vals_ = true; break;
         case CEGP_ABS_VALS_CUTOFF:
-          cegp_abs_vals_cutoff_ = std::stoul(opt.arg, NULL, 10);
+          cegp_abs_vals_cutoff_ = std::stoul(opt.arg);
           break;
         case CEGP_STRONG_ABSTRACTION: cegp_strong_abstraction_ = true; break;
         case CEG_BV_ARITH: ceg_bv_arith_ = true; break;
         case CEG_BV_ARITH_MIN_BW:
-          ceg_bv_arith_min_bw_ = std::stoul(opt.arg, NULL, 10);
+          ceg_bv_arith_min_bw_ = std::stoul(opt.arg);
           break;
         case PROMOTE_INPUTVARS: promote_inputvars_ = true; break;
         case SYGUS_OP_LVL:
-          sygus_use_operator_abstraction_ = std::stoul(opt.arg, NULL, 10);
+          sygus_use_operator_abstraction_ = std::stoul(opt.arg);
           break;
         case SYGUS_TERM_MODE:
-          sygus_term_mode_ = SyGuSTermMode(std::stoul(opt.arg, NULL, 10));
+          sygus_term_mode_ = SyGuSTermMode(std::stoul(opt.arg));
           break;
         case IC3SA_INITIAL_TERMS_LVL: {
-          ic3sa_initial_terms_lvl_ = std::stoul(opt.arg, NULL, 10);
+          ic3sa_initial_terms_lvl_ = std::stoul(opt.arg);
           if (ic3sa_initial_terms_lvl_ > 4) {
             throw PonoException(
                 "--ic3sa-initial-terms-lvl must be an integer in [0, 4]");
@@ -867,10 +867,10 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case IC3SA_INTERP: ic3sa_interp_ = true; break;
         case PRINT_WALL_TIME: print_wall_time_ = true; break;
         case BMC_BOUND_START:
-          bmc_bound_start_ = std::stoul(opt.arg, NULL, 10);
+          bmc_bound_start_ = std::stoul(opt.arg);
           break;
         case BMC_BOUND_STEP:
-          bmc_bound_step_ = std::stoul(opt.arg, NULL, 10);
+          bmc_bound_step_ = std::stoul(opt.arg);
           if (bmc_bound_step_ == 0)
             throw PonoException("--bmc-bound-step must be greater than 0");
           break;
@@ -920,7 +920,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
           break;
         case KIND_ONE_TIME_BASE_CHECK: kind_one_time_base_check_ = true; break;
         case KIND_BOUND_STEP:
-          kind_bound_step_ = std::stoul(opt.arg, NULL, 10);
+          kind_bound_step_ = std::stoul(opt.arg);
           if (kind_bound_step_ == 0)
             throw PonoException("--kind-bound-step must be greater than 0");
           break;

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -750,15 +750,15 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
           // not possible, because handled further above and exits the program
         case ENGINE: engine_ = to_engine(opt.arg); break;
         case BOUND:
-          bound_ = strtoul(opt.arg, NULL, 10);
+          bound_ = std::stoul(opt.arg, NULL, 10);
           if (bound_ >= INT_MAX) {
             throw PonoException("--bound must be less than "
                                 + std::to_string(INT_MAX) + ".");
           }
           break;
-        case PROP: prop_idx_ = strtoul(opt.arg, NULL, 10); break;
-        case VERBOSITY: verbosity_ = strtoul(opt.arg, NULL, 10); break;
-        case RANDOM_SEED: random_seed_ = strtoul(opt.arg, NULL, 10); break;
+        case PROP: prop_idx_ = std::stoul(opt.arg, NULL, 10); break;
+        case VERBOSITY: verbosity_ = std::stoul(opt.arg, NULL, 10); break;
+        case RANDOM_SEED: random_seed_ = std::stoul(opt.arg, NULL, 10); break;
         case VCDNAME:
           vcd_name_ = opt.arg;
           witness_ = true;  // implicitly enabling witness
@@ -803,15 +803,15 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case SHOW_INVAR: show_invar_ = true; break;
         case CHECK_INVAR: check_invar_ = true; break;
         case RESET: reset_name_ = opt.arg; break;
-        case RESET_BND: reset_bnd_ = strtoul(opt.arg, NULL, 10); break;
+        case RESET_BND: reset_bnd_ = std::stoul(opt.arg, NULL, 10); break;
         case CLK: clock_name_ = opt.arg; break;
         case NO_IC3_PREGEN: ic3_pregen_ = false; break;
         case NO_IC3_INDGEN: ic3_indgen_ = false; break;
         case IC3_GEN_MAX_ITER:
-          ic3_gen_max_iter_ = strtoul(opt.arg, NULL, 10);
+          ic3_gen_max_iter_ = std::stoul(opt.arg, NULL, 10);
           break;
         case MBIC3_INDGEN_MODE:
-          mbic3_indgen_mode = strtoul(opt.arg, NULL, 10);
+          mbic3_indgen_mode = std::stoul(opt.arg, NULL, 10);
           if (!(mbic3_indgen_mode >= 0 && mbic3_indgen_mode <= 2))
             throw PonoException(
                 "--ic3-indgen-mode value must be between 0 and 2.");
@@ -842,22 +842,22 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case CEGP_FORCE_RESTART: cegp_force_restart_ = true; break;
         case CEGP_ABS_VALS: cegp_abs_vals_ = true; break;
         case CEGP_ABS_VALS_CUTOFF:
-          cegp_abs_vals_cutoff_ = strtoul(opt.arg, NULL, 10);
+          cegp_abs_vals_cutoff_ = std::stoul(opt.arg, NULL, 10);
           break;
         case CEGP_STRONG_ABSTRACTION: cegp_strong_abstraction_ = true; break;
         case CEG_BV_ARITH: ceg_bv_arith_ = true; break;
         case CEG_BV_ARITH_MIN_BW:
-          ceg_bv_arith_min_bw_ = strtoul(opt.arg, NULL, 10);
+          ceg_bv_arith_min_bw_ = std::stoul(opt.arg, NULL, 10);
           break;
         case PROMOTE_INPUTVARS: promote_inputvars_ = true; break;
         case SYGUS_OP_LVL:
-          sygus_use_operator_abstraction_ = strtoul(opt.arg, NULL, 10);
+          sygus_use_operator_abstraction_ = std::stoul(opt.arg, NULL, 10);
           break;
         case SYGUS_TERM_MODE:
-          sygus_term_mode_ = SyGuSTermMode(strtoul(opt.arg, NULL, 10));
+          sygus_term_mode_ = SyGuSTermMode(std::stoul(opt.arg, NULL, 10));
           break;
         case IC3SA_INITIAL_TERMS_LVL: {
-          ic3sa_initial_terms_lvl_ = strtoul(opt.arg, NULL, 10);
+          ic3sa_initial_terms_lvl_ = std::stoul(opt.arg, NULL, 10);
           if (ic3sa_initial_terms_lvl_ > 4) {
             throw PonoException(
                 "--ic3sa-initial-terms-lvl must be an integer in [0, 4]");
@@ -867,10 +867,10 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case IC3SA_INTERP: ic3sa_interp_ = true; break;
         case PRINT_WALL_TIME: print_wall_time_ = true; break;
         case BMC_BOUND_START:
-          bmc_bound_start_ = strtoul(opt.arg, NULL, 10);
+          bmc_bound_start_ = std::stoul(opt.arg, NULL, 10);
           break;
         case BMC_BOUND_STEP:
-          bmc_bound_step_ = strtoul(opt.arg, NULL, 10);
+          bmc_bound_step_ = std::stoul(opt.arg, NULL, 10);
           if (bmc_bound_step_ == 0)
             throw PonoException("--bmc-bound-step must be greater than 0");
           break;
@@ -920,7 +920,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
           break;
         case KIND_ONE_TIME_BASE_CHECK: kind_one_time_base_check_ = true; break;
         case KIND_BOUND_STEP:
-          kind_bound_step_ = strtoul(opt.arg, NULL, 10);
+          kind_bound_step_ = std::stoul(opt.arg, NULL, 10);
           if (kind_bound_step_ == 0)
             throw PonoException("--kind-bound-step must be greater than 0");
           break;

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -807,9 +807,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case CLK: clock_name_ = opt.arg; break;
         case NO_IC3_PREGEN: ic3_pregen_ = false; break;
         case NO_IC3_INDGEN: ic3_indgen_ = false; break;
-        case IC3_GEN_MAX_ITER:
-          ic3_gen_max_iter_ = std::stoul(opt.arg);
-          break;
+        case IC3_GEN_MAX_ITER: ic3_gen_max_iter_ = std::stoul(opt.arg); break;
         case MBIC3_INDGEN_MODE:
           mbic3_indgen_mode = std::stoul(opt.arg);
           if (!(mbic3_indgen_mode >= 0 && mbic3_indgen_mode <= 2))
@@ -866,9 +864,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         }
         case IC3SA_INTERP: ic3sa_interp_ = true; break;
         case PRINT_WALL_TIME: print_wall_time_ = true; break;
-        case BMC_BOUND_START:
-          bmc_bound_start_ = std::stoul(opt.arg);
-          break;
+        case BMC_BOUND_START: bmc_bound_start_ = std::stoul(opt.arg); break;
         case BMC_BOUND_STEP:
           bmc_bound_step_ = std::stoul(opt.arg);
           if (bmc_bound_step_ == 0)

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -751,7 +751,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case ENGINE: engine_ = to_engine(opt.arg); break;
         case BOUND:
           bound_ = strtoul(opt.arg, NULL, 10);
-          if (bound_ == INT_MAX) {
+          if (bound_ >= INT_MAX) {
             throw PonoException("--bound must be less than "
                                 + std::to_string(INT_MAX) + ".");
           }

--- a/options/options.h
+++ b/options/options.h
@@ -68,7 +68,7 @@ const std::unordered_map<std::string, Engine> str2engine(
       { "sygus-pdr", SYGUS_PDR } });
 
 // SyGuS mode option
-enum SyGuSTermMode
+enum SyGuSTermMode : unsigned long
 {
   FROM_DESIGN_LEARN_EXT = 0,
   VAR_C_EXT = 1,
@@ -205,10 +205,10 @@ class PonoOptions
 
   // Pono options
   Engine engine_;
-  unsigned int prop_idx_;
-  unsigned int bound_;
-  unsigned int verbosity_;
-  unsigned int random_seed_;
+  unsigned long prop_idx_;
+  unsigned long bound_;
+  unsigned long verbosity_;
+  unsigned long random_seed_;
   bool witness_;
   bool justice_;  ///< check justice property at given index, else safety
   JusticeTranslator
@@ -226,12 +226,12 @@ class PonoOptions
   bool show_invar_;   ///< display invariant when running from command line
   bool check_invar_;  ///< check invariants (if available) when run through CLI
   // ic3 options
-  bool ic3_pregen_;                ///< generalize counterexamples in IC3
-  bool ic3_indgen_;                ///< inductive generalization in IC3
-  unsigned int ic3_gen_max_iter_;  ///< max iterations in ic3 generalization. 0
-                                   ///< means unbounded
-  unsigned int mbic3_indgen_mode;  ///< inductive generalization mode [0,2]
-  bool ic3_functional_preimage_;   ///< functional preimage in IC3
+  bool ic3_pregen_;                 ///< generalize counterexamples in IC3
+  bool ic3_indgen_;                 ///< inductive generalization in IC3
+  unsigned long ic3_gen_max_iter_;  ///< max iterations in ic3 generalization. 0
+                                    ///< means unbounded
+  unsigned long mbic3_indgen_mode;  ///< inductive generalization mode [0,2]
+  bool ic3_functional_preimage_;    ///< functional preimage in IC3
   bool ic3_unsatcore_gen_;  ///< generalize a cube during relative inductiveness
                             ///< check with unsatcore
   bool ic3ia_reduce_preds_;  ///< reduce predicates with unsatcore in IC3IA
@@ -268,8 +268,8 @@ class PonoOptions
                                      ///< increment bound
   unsigned
       sygus_accumulated_term_bound_;  ///< SyGuS Term accumulation bound count
-  unsigned sygus_use_operator_abstraction_;  ///< SyGuS abstract and avoid use
-                                             ///< some operators
+  unsigned long sygus_use_operator_abstraction_;  ///< SyGuS abstract and avoid
+                                                  ///< use some operators
   size_t ic3sa_initial_terms_lvl_;  ///< configures where to find terms for
                                     ///< initial abstraction
   bool ic3sa_interp_;
@@ -280,13 +280,13 @@ class PonoOptions
   //   they do not apply to engine 'BMC-SP')
   // Default bmc_bound_start_ == 0, which starts search for cex at
   // unrolling depth 0 like traditional BMC.
-  unsigned bmc_bound_start_;
+  unsigned long bmc_bound_start_;
   // Default: bmc_bound_step_ == 1, which results in traditional BMC
   // where every bound is checked one by one. bmc_bound_step_ is the
   // value by which the current unrolling depth is increased. For
   // bmc_bound_step_ > 1, BMC searches for cex in intervals of size
   // bmc_bound_step_.
-  unsigned bmc_bound_step_;
+  unsigned long bmc_bound_step_;
   // BMC: add negated initial state predicate in steps k > 0 (default: false)
   bool bmc_neg_init_step_;
   // BMC: double the bound in each step starting from
@@ -332,7 +332,7 @@ class PonoOptions
   // unsatisfiable
   bool kind_one_time_base_check_;
   // K-induction: amount of steps by which transition relation is unrolled
-  unsigned kind_bound_step_;
+  unsigned long kind_bound_step_;
   // Configuration for interp engine:
   // - whether to apply frontier set simplification
   bool interp_frontier_set_simpl_;


### PR DESCRIPTION
# Why
`strtoul` is proper than `atoi` in the context, and itself handles errors a lot more than `atoi`.
# What
Types are declared as `unsigned`, `unsigned int` ,`size_t`, yet use `atoi` which result in `int` type.
# How
Use `strtoul` to get proper results.