### PR TITLE
Fix the compile error in smt-switch (caused by cvc5)

### DIFF
--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -77,6 +77,11 @@ if [ ! -d "$DEPS/smt-switch" ]; then
     git clone https://github.com/stanford-centaur/smt-switch
     cd smt-switch
     git checkout -f $SMT_SWITCH_VERSION
+    # Sideload sed commands into setup-cvc5.sh to patch FindPoly.cmake and CMakeLists.txt
+    sed -i '/git checkout -f \${CVC5_VERSION}/a\
+\t# --- Sideloaded patch for FindPoly.cmake and cvc5/CMakeLists.txt ---\
+\tsed -i '\''20,28 s/^/#/'\'' "$DIR/../deps/cvc5/cmake/FindPoly.cmake"\
+\t# --- End sideloaded patch ---' "$DEPS/smt-switch/contrib/setup-cvc5.sh"
     ./contrib/setup-bitwuzla.sh
     if [ $cvc5_home = default ]; then
         ./contrib/setup-cvc5.sh


### PR DESCRIPTION
The specific version of CVC5 has an issue with finding polynomial dependencies during compilation, as mentioned in https://github.com/cvc5/cvc5/issues/9906.

This leads to several problems, including those outlined in https://github.com/stanford-centaur/pono/issues/404, and https://github.com/stanford-centaur/smt-switch/issues/401, and PR https://github.com/stanford-centaur/smt-switch/pull/402.

However, the API for operating CVC5 is closely tied to this particular version, making it challenging to update the CVC5 version in SMT-switch to avoid the errors referenced in https://github.com/stanford-centaur/smt-switch/pull/402.

After reviewing the code, I found that most of the compilation errors originate from the `FindPoly.cmake` file in CVC5.

To address this, I created a simple workaround in the `setup-smt-switch.sh` script. This should resolve the compilation issues, enabling users to compile the solver easily by following the provided manual.