### PR TITLE
Remove unneeded deps from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             cmake \
-            ninja-build \
-            libgmp-dev \
-            openjdk-8-jdk
+            ninja-build
 
       - name: Python Environment Setup
         run: |


### PR DESCRIPTION
JDK is no longer needed for building cvc5, and `libgmp-dev` is already installed on the Ubuntu images.