### PR TITLE
Do no simulate abstract CEX during IC3IA's refinement, perform BMC instead

### DIFF
--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -248,8 +248,10 @@ RefineResult IC3IA::refine()
     register_symbol_mappings(i);
     Term t;
     if (options_.ic3ia_sim_cex_) {
+      // simulate abstract cex
       t = unroller_.at_time(cex_[i], i);
     } else {
+      // perform BMC using Init and P
       if (i == 0) {
         t = unroller_.at_time(conc_ts_.init(), i);
       } else if (i + 1 == cex_length) {

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -246,8 +246,18 @@ RefineResult IC3IA::refine()
   for (size_t i = 0; i < cex_length; ++i) {
     // make sure to_solver_ cache is populated with unrolled symbols
     register_symbol_mappings(i);
-
-    Term t = unroller_.at_time(cex_[i], i);
+    Term t;
+    if (options_.ic3ia_sim_cex_) {
+      t = unroller_.at_time(cex_[i], i);
+    } else {
+      if (i == 0) {
+        t = unroller_.at_time(conc_ts_.init(), i);
+      } else if (i + 1 == cex_length) {
+        t = unroller_.at_time(bad_, i);
+      } else {
+        t = solver_->make_term(Not, unroller_.at_time(bad_, i));
+      }
+    }
     if (i + 1 < cex_length) {
       t = solver_->make_term(And, t, unroller_.at_time(conc_ts_.trans(), i));
     }

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -342,7 +342,8 @@ const option::Descriptor usage[] = {
     "",
     "no-ic3ia-sim-cex",
     Arg::None,
-    "  --no-ic3ia-sim-cex \tTODO." },
+    "  --no-ic3ia-sim-cex \tDo not simulate abstract cex during refinement, "
+    "perform BMC instead." },
   { NO_IC3SA_FUNC_REFINE,
     0,
     "",

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -64,6 +64,7 @@ enum optionIndex
   NO_IC3_UNSATCORE_GEN,
   NO_IC3IA_REDUCE_PREDS,
   NO_IC3IA_TRACK_IMPORTANT_VARS,
+  NO_IC3IA_SIM_CEX,
   NO_IC3SA_FUNC_REFINE,
   MBIC3_INDGEN_MODE,
   PROFILING_LOG_FILENAME,
@@ -336,6 +337,12 @@ const option::Descriptor usage[] = {
     Arg::None,
     "  --no-ic3ia-track-important-vars \tIgnore tracked important variables "
     "when picking predicates." },
+  { NO_IC3IA_SIM_CEX,
+    0,
+    "",
+    "no-ic3ia-sim-cex",
+    Arg::None,
+    "  --no-ic3ia-sim-cex \tTODO." },
   { NO_IC3SA_FUNC_REFINE,
     0,
     "",
@@ -775,6 +782,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case NO_IC3_UNSATCORE_GEN: ic3_unsatcore_gen_ = false; break;
         case NO_IC3IA_REDUCE_PREDS: ic3ia_reduce_preds_ = false;
         case NO_IC3IA_TRACK_IMPORTANT_VARS: ic3ia_track_important_vars_ = false;
+        case NO_IC3IA_SIM_CEX: ic3ia_sim_cex_ = false; break;
         case NO_IC3SA_FUNC_REFINE: ic3sa_func_refine_ = false; break;
         case PROFILING_LOG_FILENAME:
 #ifndef WITH_PROFILING

--- a/options/options.h
+++ b/options/options.h
@@ -226,8 +226,8 @@ class PonoOptions
   bool ic3ia_reduce_preds_;  ///< reduce predicates with unsatcore in IC3IA
   bool ic3ia_track_important_vars_;  ///< prioritize predicates with marked
                                      ///< important variables
-  bool ic3ia_sim_cex_;               //< TODO
-  bool ic3sa_func_refine_;           ///< try functional unrolling in refinement
+  bool ic3ia_sim_cex_;      ///< simulate abstract cex during IC3IA's refinement
+  bool ic3sa_func_refine_;  ///< try functional unrolling in refinement
   std::string profiling_log_filename_;
   bool pseudo_init_prop_;  ///< replace init and prop with boolean state vars
   bool assume_prop_;       ///< assume property in pre-state

--- a/options/options.h
+++ b/options/options.h
@@ -122,6 +122,7 @@ class PonoOptions
         ic3_unsatcore_gen_(default_ic3_unsatcore_gen_),
         ic3ia_reduce_preds_(default_ic3ia_reduce_preds_),
         ic3ia_track_important_vars_(default_ic3ia_track_important_vars_),
+        ic3ia_sim_cex_(default_ic3ia_sim_cex_),
         ic3sa_func_refine_(default_ic3sa_func_refine_),
         profiling_log_filename_(default_profiling_log_filename_),
         pseudo_init_prop_(default_pseudo_init_prop_),
@@ -225,6 +226,7 @@ class PonoOptions
   bool ic3ia_reduce_preds_;  ///< reduce predicates with unsatcore in IC3IA
   bool ic3ia_track_important_vars_;  ///< prioritize predicates with marked
                                      ///< important variables
+  bool ic3ia_sim_cex_;               //< TODO
   bool ic3sa_func_refine_;           ///< try functional unrolling in refinement
   std::string profiling_log_filename_;
   bool pseudo_init_prop_;  ///< replace init and prop with boolean state vars
@@ -355,6 +357,7 @@ class PonoOptions
   static const bool default_ic3_unsatcore_gen_ = true;
   static const bool default_ic3ia_reduce_preds_ = true;
   static const bool default_ic3ia_track_important_vars_ = true;
+  static const bool default_ic3ia_sim_cex_ = true;
   static const bool default_ic3sa_func_refine_ = true;
   static const std::string default_profiling_log_filename_;
   static const bool default_pseudo_init_prop_ = false;


### PR DESCRIPTION
This PR introduces an alternative refinement method for abstractions in IC3IA.
Rather than simulating and checking the feasibility of the abstract counterexample (CEX),
a BMC query (using `Init` and `P`) is posed.

While this approach does not improve IC3IA’s [overall performance](https://www.cip.ifi.lmu.de/~chien/benchexec-results/pono/0.1.1-295-ga55bb6b/itp-engines.msat-incr.table.html#/?hidden0=4,2&hidden1=4,2&hidden=2,3,4,5,6,7,8,9),
it is capable of solving certain tasks that the default method (simulating the abstract CEX) cannot.
Therefore, it is available as an option but not enabled by default.
