### PR TITLE
Add clangd configuration file

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  CompilationDatabase: build/


### PR DESCRIPTION
This is a follow-up to 3d57512, which sets the option to generate a compilation database. `clangd` and tools based on it need to be told the location of this file, which is inside the build directory.