### PR TITLE
Export violation witnesses for IC3 engines

### DIFF
--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -175,6 +175,7 @@ ProverResult IC3Base::check_until(int k)
       } else if (s == REFINE_NONE) {
         // this is a real counterexample
         assert(cex_.size());
+        compute_witness();
         return ProverResult::FALSE;
       } else {
         assert(s == REFINE_FAIL);
@@ -193,11 +194,6 @@ ProverResult IC3Base::check_until(int k)
   return ProverResult::UNKNOWN;
 }
 
-bool IC3Base::witness(std::vector<smt::UnorderedTermMap> & out)
-{
-  throw PonoException("IC3 witness NYI");
-}
-
 size_t IC3Base::witness_length() const
 {
   // expecting there to have been a witness computed
@@ -206,6 +202,40 @@ size_t IC3Base::witness_length() const
 }
 
 // Protected Methods
+
+bool IC3Base::compute_witness()
+{
+  solver_->reset_assertions();
+
+  // construct base BMC query
+  solver_->assert_formula(unroller_.at_time(ts_.init(), 0));
+  for (size_t t = 0; t < witness_length(); ++t) {
+    solver_->assert_formula(unroller_.at_time(ts_.trans(), t));
+  }
+  solver_->assert_formula(unroller_.at_time(bad_, witness_length()));
+
+  // make stored cex additional constraint to guide the search
+  TermVec state_constraints;
+  state_constraints.reserve(witness_length());
+  for (size_t t = 0; t < witness_length(); ++t) {
+    state_constraints.push_back(unroller_.at_time(cex_.at(t), t));
+  }
+
+  Result r = solver_->check_sat_assuming(state_constraints);
+  if (!r.is_sat()) {
+    logger.log(1,
+               "IC3Base: failed to reconstruct CEX path with state "
+               "constraints, falling back to plain BMC");
+    r = solver_->check_sat();
+  }
+
+  if (!r.is_sat()) {
+    logger.log(1, "IC3Base: failed to compute witness");
+    return false;
+  }
+
+  return super::compute_witness();
+}
 
 IC3Formula IC3Base::ic3formula_disjunction(const TermVec & c) const
 {

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -174,11 +174,11 @@ class IC3Base : public Prover
 
   ProverResult check_until(int k) override;
 
-  bool witness(std::vector<smt::UnorderedTermMap> & out) override;
-
   size_t witness_length() const override;
 
  protected:
+  bool compute_witness() override;
+
   smt::UnsatCoreReducer reducer_;
 
   ///< keeps track of the current context-level of the solver

--- a/engines/ic3sa.cpp
+++ b/engines/ic3sa.cpp
@@ -62,6 +62,9 @@ IC3SA::IC3SA(const SafetyProperty & p,
       boolsort_(solver_->make_sort(BOOL)),
       longest_unroll_(0)
 {
+  // since we passed a fresh RelationalTransitionSystem as the main TS
+  // need to point orig_ts_ to the right place
+  orig_ts_ = ts;
   engine_ = Engine::IC3SA_ENGINE;
   approx_pregen_ = true;
 }

--- a/engines/prover.h
+++ b/engines/prover.h
@@ -92,7 +92,7 @@ class Prover
    *  populates witness_
    *  @return true on success
    */
-  bool compute_witness();
+  virtual bool compute_witness();
 
   /** Returns the reference of the interface ts, which is a copy of orig_ts but
    *  built using solver_. By default, the method returns a reference to ts_.


### PR DESCRIPTION
IC3 engines stores counterexample path in `cex_`,
which, AFAICS, only contains values of state variables.
We can use this information and do a BMC check to get the input values at each time step.

In this PR, a simple solution as describe above is implemented.
In later PRs, we could optimize the code to avoid recomputation.
(For example, in ic3sa and ic3ia, such BMC checks are already performed during refinement.)