### PR TITLE
Replace Property with SafetyProperty in engines and tests

### DIFF
--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -91,8 +91,8 @@ ProverResult CegProphecyArrays<MsatIC3IA>::prove()
       reached_k_++;
     } while (num_added_axioms_);
 
-    Property latest_prop(super::solver_,
-                         super::solver_->make_term(Not, super::bad_));
+    SafetyProperty latest_prop(super::solver_,
+                               super::solver_->make_term(Not, super::bad_));
     SmtSolver s = create_solver_for(
         super::solver_->get_solver_enum(), super::engine_, false);
     shared_ptr<Prover> prover =

--- a/engines/fairness_prover.cpp
+++ b/engines/fairness_prover.cpp
@@ -1,0 +1,165 @@
+#include <cassert>
+#include <climits>
+#include <functional>
+
+#include "core/rts.h"
+#include "engines/prover.h"
+#include "modifiers/static_coi.h"
+#include "smt/available_solvers.h"
+#include "utils/logger.h"
+
+using namespace smt;
+using namespace std;
+
+namespace pono {
+
+SafetyProver::SafetyProver(const SafetyProperty & p,
+                           const TransitionSystem & ts,
+                           const smt::SmtSolver & s,
+                           PonoOptions opt)
+    : Prover(p, ts, s, opt),
+      bad_(solver_->make_term(smt::PrimOp::Not,
+                              ts_.solver() == orig_property_.solver()
+                                  ? orig_property_.prop_term()
+                                  : to_prover_solver_.transfer_term(
+                                        orig_property_.prop_term(), BOOL))),
+      engine_(opt.justice_engine_)
+{
+}
+
+SafetyProver::~SafetyProver() {}
+
+void SafetyProver::initialize()
+{
+  if (initialized_) {
+    return;
+  }
+
+  reached_k_ = -1;
+
+  if (!ts_.only_curr(bad_)) {
+    throw PonoException(
+        "Property should not contain inputs or next state variables");
+  }
+
+  initialized_ = true;
+}
+
+bool SafetyProver::witness(std::vector<UnorderedTermMap> & out)
+{
+  if (!witness_.size()) {
+    throw PonoException(
+        "Recovering witness failed. Make sure that there was "
+        "a counterexample and that the engine supports witness generation.");
+  }
+
+  function<Term(const Term &, SortKind)> transfer_to_prover_as;
+  function<Term(const Term &, SortKind)> transfer_to_orig_ts_as;
+  TermTranslator to_orig_ts_solver(orig_ts_.solver());
+  if (solver_ == orig_ts_.solver()) {
+    // don't need to transfer terms if the solvers are the same
+    transfer_to_prover_as = [](const Term & t, SortKind sk) { return t; };
+    transfer_to_orig_ts_as = [](const Term & t, SortKind sk) { return t; };
+  } else {
+    // need to add symbols to cache
+    UnorderedTermMap & cache = to_orig_ts_solver.get_cache();
+    for (const auto & v : orig_ts_.statevars()) {
+      cache[to_prover_solver_.transfer_term(v)] = v;
+    }
+    for (const auto & v : orig_ts_.inputvars()) {
+      cache[to_prover_solver_.transfer_term(v)] = v;
+    }
+
+    transfer_to_prover_as = [this](const Term & t, SortKind sk) {
+      return to_prover_solver_.transfer_term(t, sk);
+    };
+    transfer_to_orig_ts_as = [&to_orig_ts_solver](const Term & t, SortKind sk) {
+      return to_orig_ts_solver.transfer_term(t, sk);
+    };
+  }
+
+  bool success = true;
+
+  // Some backends don't support full witnesses
+  // it will still populate state variables, but will return false instead of
+  // true
+  for (auto wit_map : witness_) {
+    out.push_back(UnorderedTermMap());
+    UnorderedTermMap & map = out.back();
+
+    for (const auto & v : orig_ts_.statevars()) {
+      const SortKind & sk = v->get_sort()->get_sort_kind();
+      const Term & pv = transfer_to_prover_as(v, sk);
+      map[v] = transfer_to_orig_ts_as(wit_map.at(pv), sk);
+    }
+
+    for (const auto & v : orig_ts_.inputvars()) {
+      const SortKind & sk = v->get_sort()->get_sort_kind();
+      const Term & pv = transfer_to_prover_as(v, sk);
+      try {
+        map[v] = transfer_to_orig_ts_as(wit_map.at(pv), sk);
+      }
+      catch (std::exception & e) {
+        success = false;
+        break;
+      }
+    }
+
+    if (success) {
+      for (const auto & elem : orig_ts_.named_terms()) {
+        const SortKind & sk = elem.second->get_sort()->get_sort_kind();
+        const Term & pt = transfer_to_prover_as(elem.second, sk);
+        try {
+          map[elem.second] = transfer_to_orig_ts_as(wit_map.at(pt), sk);
+        }
+        catch (std::exception & e) {
+          success = false;
+          break;
+        }
+      }
+    }
+  }
+
+  return success;
+}
+
+Term SafetyProver::invar()
+{
+  if (!invar_) {
+    throw PonoException(
+        "Failed to return invar. Be sure that the property was proven by an "
+        "engine the supports returning invariants.");
+  }
+  return to_orig_ts(invar_, BOOL);
+}
+
+bool SafetyProver::compute_witness()
+{
+  // TODO: make sure the solver state is SAT
+
+  for (int i = 0; i <= reached_k_ + 1; ++i) {
+    witness_.push_back(UnorderedTermMap());
+    UnorderedTermMap & map = witness_.back();
+
+    for (const auto & v : ts_.statevars()) {
+      const Term & vi = unroller_.at_time(v, i);
+      const Term & r = solver_->get_value(vi);
+      map[v] = r;
+    }
+
+    for (const auto & v : ts_.inputvars()) {
+      const Term & vi = unroller_.at_time(v, i);
+      const Term & r = solver_->get_value(vi);
+      map[v] = r;
+    }
+
+    for (const auto & elem : ts_.named_terms()) {
+      const Term & ti = unroller_.at_time(elem.second, i);
+      map[elem.second] = solver_->get_value(ti);
+    }
+  }
+
+  return true;
+}
+
+}  // namespace pono

--- a/engines/msat_ic3ia.cpp
+++ b/engines/msat_ic3ia.cpp
@@ -31,7 +31,7 @@ using namespace std;
 
 namespace pono {
 
-MsatIC3IA::MsatIC3IA(const Property & p,
+MsatIC3IA::MsatIC3IA(const SafetyProperty & p,
                      const TransitionSystem & ts,
                      const SmtSolver & solver,
                      PonoOptions opt)

--- a/engines/msat_ic3ia.h
+++ b/engines/msat_ic3ia.h
@@ -25,7 +25,7 @@ namespace pono {
 class MsatIC3IA : public Prover
 {
  public:
-  MsatIC3IA(const Property & p,
+  MsatIC3IA(const SafetyProperty & p,
             const TransitionSystem & ts,
             const smt::SmtSolver & solver,
             PonoOptions opt = PonoOptions());

--- a/tests/encoders/test_btor2.cpp
+++ b/tests/encoders/test_btor2.cpp
@@ -63,7 +63,7 @@ TEST_P(Btor2UnitTests, OverflowEncoding)
   filename += "/tests/encoders/inputs/btor2/mulo-test.btor2";
   BTOR2Encoder be(filename, fts);
   EXPECT_EQ(be.propvec().size(), 1);
-  Property p(fts.solver(), be.propvec()[0]);
+  SafetyProperty p(fts.solver(), be.propvec()[0]);
   KInduction kind(p, fts, s);
   ProverResult r = kind.check_until(2);
   EXPECT_EQ(r, ProverResult::TRUE);
@@ -80,7 +80,7 @@ TEST_P(Btor2UnitTests, InputConstraints)
   filename += "/tests/encoders/inputs/btor2/mulo-test.btor2";
   BTOR2Encoder be(filename, fts);
   EXPECT_EQ(be.propvec().size(), 1);
-  Property p(fts.solver(), be.propvec()[0]);
+  SafetyProperty p(fts.solver(), be.propvec()[0]);
   Bmc bmc(p, fts, s);
   ProverResult r = bmc.check_until(6);
   ASSERT_NE(r, ProverResult::FALSE);
@@ -97,7 +97,7 @@ TEST_P(Btor2UnitTests, InputProp)
   filename += "/tests/encoders/inputs/btor2/input-in-bad.btor2";
   BTOR2Encoder be(filename, fts);
   EXPECT_EQ(be.propvec().size(), 1);
-  Property p(fts.solver(), be.propvec()[0]);
+  SafetyProperty p(fts.solver(), be.propvec()[0]);
   Bmc bmc(p, fts, s);
   ProverResult r = bmc.check_until(0);
   EXPECT_EQ(r, ProverResult::FALSE);
@@ -113,7 +113,7 @@ TEST_P(Btor2UnitTests, InvalidSmtlibSymbol)
   string filename = STRFY(PONO_SRC_DIR);
   filename += "/tests/encoders/inputs/btor2/invalid-smtlib-symbol.btor2";
   BTOR2Encoder be(filename, fts);
-  Property p(fts.solver(), be.propvec()[0]);
+  SafetyProperty p(fts.solver(), be.propvec()[0]);
   Bmc bmc(p, fts, s);
   ProverResult r = bmc.check_until(0);
   ASSERT_NE(r, ProverResult::ERROR);
@@ -129,7 +129,7 @@ TEST_P(Btor2UnitTests, InitStateWithBool)
   string filename = STRFY(PONO_SRC_DIR);
   filename += "/tests/encoders/inputs/btor2/bool-init.btor2";
   BTOR2Encoder be(filename, fts);
-  Property p(fts.solver(), be.propvec()[0]);
+  SafetyProperty p(fts.solver(), be.propvec()[0]);
   Bmc bmc(p, fts, s);
   ProverResult r = bmc.check_until(0);
   ASSERT_NE(r, ProverResult::ERROR);

--- a/tests/encoders/test_smv.cpp
+++ b/tests/encoders/test_smv.cpp
@@ -36,7 +36,7 @@ TEST_P(SmvFileUnitTests, Encode)
   cout << "Reading file: " << filename << endl;
   SMVEncoder se(filename, rts);
 
-  Property prop(rts.solver(), se.propvec()[0]);
+  SafetyProperty prop(rts.solver(), se.propvec()[0]);
   KInduction kind(prop, rts, s);
   ProverResult res = kind.check_until(10);
   EXPECT_EQ(res, benchmark.second);

--- a/tests/test_engines.cpp
+++ b/tests/test_engines.cpp
@@ -284,7 +284,7 @@ TEST_P(InterpOptionsTests, CounterSystemUnsafe)
   Term x = fts.named_terms().at("x");
 
   Term prop_term = s->make_term(BVUlt, x, max_val);
-  Property p(s, prop_term);
+  SafetyProperty p(s, prop_term);
 
   InterpolantMC interp_mc(p, fts, s);
   ProverResult r = interp_mc.prove();
@@ -296,7 +296,7 @@ TEST_P(InterpOptionsTests, CounterSystemSafe)
   Term x = fts.named_terms().at("x");
 
   Term prop_term = s->make_term(BVUle, x, max_val);
-  Property p(s, prop_term);
+  SafetyProperty p(s, prop_term);
 
   InterpolantMC interp_mc(p, fts, s);
   ProverResult r = interp_mc.prove();

--- a/tests/test_msat_ic3ia.cpp
+++ b/tests/test_msat_ic3ia.cpp
@@ -37,7 +37,7 @@ TEST_P(MsatIC3IAUnitTests, IntCounterSafe)
   rts.constrain_init(rts.make_term(Equal, c, rts.make_term(0, intsort)));
   rts.assign_next(c, rts.make_term(Plus, c, rts.make_term(1, intsort)));
 
-  Property p(s, rts.make_term(Ge, c, rts.make_term(0, intsort)));
+  SafetyProperty p(s, rts.make_term(Ge, c, rts.make_term(0, intsort)));
 
   MsatIC3IA msat_ic3ia(p, rts, s);
   ProverResult res = msat_ic3ia.prove();
@@ -61,7 +61,7 @@ TEST_P(MsatIC3IAUnitTests, IntCounterUnsafe)
                     rts.next(c),
                     rts.make_term(Plus, c, rts.make_term(1, intsort)))));
 
-  Property p(s, rts.make_term(Ge, c, rts.make_term(0, intsort)));
+  SafetyProperty p(s, rts.make_term(Ge, c, rts.make_term(0, intsort)));
 
   MsatIC3IA msat_ic3ia(p, rts, s);
   ProverResult res = msat_ic3ia.prove();


### PR DESCRIPTION
This PR follows up on #415 and replaces remaining instances of the deprecated usage of `Property`.