### PR TITLE
Convert size_t options to unsigned long

### DIFF
--- a/engines/cegar_ops_uf.h
+++ b/engines/cegar_ops_uf.h
@@ -35,7 +35,7 @@ class CegarOpsUf : public CEGAR<Prover_T>
 
   void set_ops_to_abstract(const smt::UnorderedOpSet & ops_to_abstract);
 
-  void set_min_bitwidth(size_t w) { oa_.set_min_bitwidth(w); };
+  void set_min_bitwidth(unsigned long w) { oa_.set_min_bitwidth(w); };
 
   void initialize() override;
 

--- a/engines/cegar_values.cpp
+++ b/engines/cegar_values.cpp
@@ -54,7 +54,7 @@ class ValueAbstractor : public smt::IdentityWalker
  public:
   ValueAbstractor(TransitionSystem & ts,
                   UnorderedTermMap & abstracted_values,
-                  size_t cutoff)
+                  unsigned long cutoff)
       : smt::IdentityWalker(ts.solver(), false),
         ts_(ts),
         abstracted_values_(abstracted_values),
@@ -161,7 +161,7 @@ class ValueAbstractor : public smt::IdentityWalker
 
   SmtSolver fresh_solver_;  ///< solver just for the range check
   TermTranslator to_fresh_solver_;
-  size_t cutoff_;
+  unsigned long cutoff_;
 };
 
 template <class Prover_T>

--- a/modifiers/control_signals.cpp
+++ b/modifiers/control_signals.cpp
@@ -55,7 +55,7 @@ void toggle_clock(TransitionSystem & ts, const Term & clock_symbol)
 
 Term add_reset_seq(TransitionSystem & ts,
                    const Term & reset_symbol,
-                   size_t reset_bnd)
+                   unsigned long reset_bnd)
 {
   const SmtSolver & s = ts.solver();
   Sort reset_sort = reset_symbol->get_sort();

--- a/modifiers/control_signals.h
+++ b/modifiers/control_signals.h
@@ -42,6 +42,6 @@ void toggle_clock(TransitionSystem & ts, const smt::Term & clock_symbol);
  */
 smt::Term add_reset_seq(TransitionSystem & ts,
                         const smt::Term & reset_symbol,
-                        size_t reset_bnd = 1);
+                        unsigned long reset_bnd = 1);
 
 }  // namespace pono

--- a/modifiers/ops_abstractor.h
+++ b/modifiers/ops_abstractor.h
@@ -35,7 +35,7 @@ class OpsAbstractor : public Abstractor
 
   void set_ops_to_abstract(const smt::UnorderedOpSet & ops_to_abstract);
 
-  void set_min_bitwidth(size_t w) { min_bw_ = w; };
+  void set_min_bitwidth(unsigned long w) { min_bw_ = w; };
 
   void do_abstraction();
 
@@ -71,7 +71,7 @@ class OpsAbstractor : public Abstractor
 
   smt::UnorderedOpSet ops_to_abstract_;
 
-  size_t min_bw_;
+  unsigned long min_bw_;
 
   std::unordered_map<std::string, smt::Term> abs_op_symbols_;
   std::unordered_map<smt::Term, smt::Op> abs_symbols_to_op_;

--- a/options/options.h
+++ b/options/options.h
@@ -258,8 +258,8 @@ class PonoOptions
       sygus_accumulated_term_bound_;  ///< SyGuS Term accumulation bound count
   unsigned sygus_use_operator_abstraction_;  ///< SyGuS abstract and avoid use
                                              ///< some operators
-  unsigned long ic3sa_initial_terms_lvl_;    ///< configures where to find terms
-                                           ///< for initial abstraction
+  unsigned long ic3sa_initial_terms_lvl_;    ///< configures where to find
+                                             ///< terms for initial abstraction
   bool ic3sa_interp_;
   // print wall clock time spent in entire execution
   bool print_wall_time_;

--- a/options/options.h
+++ b/options/options.h
@@ -203,7 +203,7 @@ class PonoOptions
       justice_translator_;  ///< liveness to safety translation algorithm
   std::string vcd_name_;
   std::string reset_name_;
-  size_t reset_bnd_;
+  unsigned long reset_bnd_;
   std::string clock_name_;
   std::string filename_;
   smt::SolverEnum smt_solver_;        ///< underlying smt solver
@@ -239,11 +239,12 @@ class PonoOptions
   bool cegp_force_restart_;        ///< force underlying engine to restart after
                                    ///< refinement
   bool cegp_abs_vals_;  ///< abstract values on top of ceg-prophecy-arrays
-  size_t cegp_abs_vals_cutoff_;   ///< cutoff to abstract a value
+  unsigned long cegp_abs_vals_cutoff_;  ///< cutoff to abstract a value
   bool cegp_strong_abstraction_;  ///< use strong abstraction (no equality UFs)
   bool ceg_bv_arith_;             ///< CEGAR -- Abstract BV arithmetic operators
-  size_t ceg_bv_arith_min_bw_;    ///< Only abstract operators having bitwidth
-                                  ///< strictly greater than this number
+  unsigned long
+      ceg_bv_arith_min_bw_;  ///< Only abstract operators having bitwidth
+                             ///< strictly greater than this number
   bool promote_inputvars_;
   // sygus-pdr options
   SyGuSTermMode sygus_term_mode_;      ///< SyGuS term production mode
@@ -257,8 +258,8 @@ class PonoOptions
       sygus_accumulated_term_bound_;  ///< SyGuS Term accumulation bound count
   unsigned sygus_use_operator_abstraction_;  ///< SyGuS abstract and avoid use
                                              ///< some operators
-  size_t ic3sa_initial_terms_lvl_;  ///< configures where to find terms for
-                                    ///< initial abstraction
+  unsigned long ic3sa_initial_terms_lvl_;    ///< configures where to find terms
+                                           ///< for initial abstraction
   bool ic3sa_interp_;
   // print wall clock time spent in entire execution
   bool print_wall_time_;
@@ -335,7 +336,7 @@ class PonoOptions
   static const bool default_static_coi_ = false;
   static const bool default_show_invar_ = false;
   static const bool default_check_invar_ = false;
-  static const size_t default_reset_bnd_ = 1;
+  static const unsigned long default_reset_bnd_ = 1;
   // TODO distinguish when solver is not set and choose a
   //      good solver for the provided engine automatically
   static const smt::SolverEnum default_smt_solver_ = smt::BZLA;
@@ -365,10 +366,10 @@ class PonoOptions
   static const bool default_cegp_nonconsec_axiom_red_ = true;
   static const bool default_cegp_force_restart_ = false;
   static const bool default_cegp_abs_vals_ = false;
-  static const size_t default_cegp_abs_vals_cutoff_ = 100;
+  static const unsigned long default_cegp_abs_vals_cutoff_ = 100;
   static const bool default_cegp_strong_abstraction_ = false;
   static const bool default_ceg_bv_arith_ = false;
-  static const size_t default_ceg_bv_arith_min_bw_ = 16;
+  static const unsigned long default_ceg_bv_arith_min_bw_ = 16;
   static const bool default_promote_inputvars_ = false;
   static const SyGuSTermMode default_sygus_term_mode_ = TERM_MODE_AUTO;
   static const unsigned default_sygus_term_extract_depth_ = 0;
@@ -377,7 +378,7 @@ class PonoOptions
   static const unsigned default_sygus_accumulated_term_bound_ = 0;
   static const unsigned default_sygus_use_operator_abstraction_ = 0;
   // default is the highest level
-  static const size_t default_ic3sa_initial_terms_lvl_ = 4;
+  static const unsigned long default_ic3sa_initial_terms_lvl_ = 4;
   static const bool default_ic3sa_interp_ = false;
   static const bool default_print_wall_time_ = false;
   static const unsigned default_bmc_bound_start_ = 0;


### PR DESCRIPTION
Necessitated by the lack of standard string conversion functions to `size_t`, see #406.

We also don't need any of these to be `size_t`; `unsigned long` is perfectly fine.