### PR TITLE
Abstract bit-vector arithmetic using free state symbols

### DIFF
--- a/engines/cegar_ops_uf.cpp
+++ b/engines/cegar_ops_uf.cpp
@@ -43,7 +43,7 @@ CegarOpsUf<Prover_T>::CegarOpsUf(const SafetyProperty & p,
     : super(p, create_fresh_ts(ts.is_functional(), solver), solver, opt),
       conc_ts_(ts, super::to_prover_solver_),
       prover_ts_(super::prover_interface_ts()),
-      oa_(conc_ts_, prover_ts_),
+      oa_(conc_ts_, prover_ts_, opt.ceg_bv_arith_as_free_symbol_),
       cegopsuf_solver_(
           create_solver(solver->get_solver_enum(), opt.logging_smt_solver_)),
       to_cegopsuf_solver_(cegopsuf_solver_),

--- a/modifiers/ops_abstractor.h
+++ b/modifiers/ops_abstractor.h
@@ -26,7 +26,7 @@ class OpsAbstractor : public Abstractor
  public:
   OpsAbstractor(const TransitionSystem & conc_ts,
                 TransitionSystem & abs_ts,
-                bool abs_using_free_symbols);
+                bool abs_using_free_symbols = false);
 
   typedef Abstractor super;
 

--- a/modifiers/ops_abstractor.h
+++ b/modifiers/ops_abstractor.h
@@ -24,7 +24,9 @@ namespace pono {
 class OpsAbstractor : public Abstractor
 {
  public:
-  OpsAbstractor(const TransitionSystem & conc_ts, TransitionSystem & abs_ts);
+  OpsAbstractor(const TransitionSystem & conc_ts,
+                TransitionSystem & abs_ts,
+                bool abs_using_free_symbols);
 
   typedef Abstractor super;
 
@@ -78,6 +80,8 @@ class OpsAbstractor : public Abstractor
 
   smt::UnorderedTermMap abs_terms_;  // abs uf to concrete operator -- only
                                      // replace the top-level uf
+
+  const bool abs_using_free_symbols_;
 };
 
 }  // namespace pono

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -461,8 +461,9 @@ const option::Descriptor usage[] = {
     "",
     "ceg-bv-arith-as-free-symbol",
     Arg::None,
-    "  --ceg-bv-arith-as-free-symbol \tabstractBV arithmetic operators using "
-    "free symbols (unconstrained inputs) instead of uninterpreted functions" },
+    "  --ceg-bv-arith-as-free-symbol \tabstract BV arithmetic operators using "
+    "free symbols (unconstrained state variables) instead of uninterpreted "
+    "functions" },
   { CEG_BV_ARITH_MIN_BW,
     0,
     "",

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -80,6 +80,7 @@ enum optionIndex
   CEGP_ABS_VALS_CUTOFF,
   CEGP_STRONG_ABSTRACTION,
   CEG_BV_ARITH,
+  CEG_BV_ARITH_AS_FREE_SYMBOL,
   CEG_BV_ARITH_MIN_BW,
   PROMOTE_INPUTVARS,
   SYGUS_OP_LVL,
@@ -454,7 +455,14 @@ const option::Descriptor usage[] = {
     "ceg-bv-arith",
     Arg::None,
     "  --ceg-bv-arith \tabstraction-refinement for the BV arithmetic operators "
-    "(mul, div, rem, mod)" },
+    "(mul, div, rem, mod) using uninterpreted functions." },
+  { CEG_BV_ARITH_AS_FREE_SYMBOL,
+    0,
+    "",
+    "ceg-bv-arith-as-free-symbol",
+    Arg::None,
+    "  --ceg-bv-arith-as-free-symbol \tabstractBV arithmetic operators using "
+    "free symbols (unconstrained inputs) instead of uninterpreted functions" },
   { CEG_BV_ARITH_MIN_BW,
     0,
     "",
@@ -856,6 +864,9 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
           break;
         case CEGP_STRONG_ABSTRACTION: cegp_strong_abstraction_ = true; break;
         case CEG_BV_ARITH: ceg_bv_arith_ = true; break;
+        case CEG_BV_ARITH_AS_FREE_SYMBOL:
+          ceg_bv_arith_as_free_symbol_ = true;
+          break;
         case CEG_BV_ARITH_MIN_BW:
           ceg_bv_arith_min_bw_ = std::stoul(opt.arg);
           break;

--- a/options/options.h
+++ b/options/options.h
@@ -145,6 +145,7 @@ class PonoOptions
         cegp_abs_vals_cutoff_(default_cegp_abs_vals_cutoff_),
         cegp_strong_abstraction_(default_cegp_strong_abstraction_),
         ceg_bv_arith_(default_ceg_bv_arith_),
+        ceg_bv_arith_as_free_symbol_(default_ceg_bv_arith_as_free_symbol_),
         ceg_bv_arith_min_bw_(default_ceg_bv_arith_min_bw_),
         promote_inputvars_(default_promote_inputvars_),
         sygus_term_mode_(default_sygus_term_mode_),
@@ -258,6 +259,9 @@ class PonoOptions
   unsigned long cegp_abs_vals_cutoff_;  ///< cutoff to abstract a value
   bool cegp_strong_abstraction_;  ///< use strong abstraction (no equality UFs)
   bool ceg_bv_arith_;             ///< CEGAR -- Abstract BV arithmetic operators
+  bool ceg_bv_arith_as_free_symbol_;  ///< Abstract BV arithmetic operators as
+                                      ///< free symbols (instead of
+                                      ///< uninterpreted functions)
   unsigned long
       ceg_bv_arith_min_bw_;  ///< Only abstract operators having bitwidth
                              ///< strictly greater than this number
@@ -396,6 +400,7 @@ class PonoOptions
   static const unsigned long default_cegp_abs_vals_cutoff_ = 100;
   static const bool default_cegp_strong_abstraction_ = false;
   static const bool default_ceg_bv_arith_ = false;
+  static const bool default_ceg_bv_arith_as_free_symbol_ = false;
   static const unsigned long default_ceg_bv_arith_min_bw_ = 16;
   static const bool default_promote_inputvars_ = false;
   static const SyGuSTermMode default_sygus_term_mode_ = TERM_MODE_AUTO;

--- a/tests/test_cegar_ops_uf.cpp
+++ b/tests/test_cegar_ops_uf.cpp
@@ -43,12 +43,14 @@ FunctionalTransitionSystem counter_ts(SmtSolver s, const Term & x)
 }
 
 class CegOpsUfTests : public ::testing::Test,
-                      public ::testing::WithParamInterface<Engine>
+                      public ::testing::WithParamInterface<tuple<Engine, bool>>
 {
  protected:
   void SetUp() override
   {
-    opts.engine_ = GetParam();
+    tuple<Engine, bool> test_param = GetParam();
+    opts.engine_ = get<0>(test_param);
+    opts.ceg_bv_arith_as_free_symbol_ = get<1>(test_param);
     // use cvc5 as the base solver as it supports both BV and Int
     opts.smt_solver_ = SolverEnum::CVC5;
     solver = create_solver(opts.smt_solver_);
@@ -136,8 +138,10 @@ TEST_P(CegOpsUfTests, IntSimpleUnsafe)
   ASSERT_EQ(r, ProverResult::FALSE);
 }
 
-INSTANTIATE_TEST_SUITE_P(ParameterizedCegOpsUfTests,
-                         CegOpsUfTests,
-                         testing::ValuesIn(get_cegar_ops_uf_engines()));
+INSTANTIATE_TEST_SUITE_P(
+    ParameterizedCegOpsUfTests,
+    CegOpsUfTests,
+    testing::Combine(testing::ValuesIn(get_cegar_ops_uf_engines()),
+                     testing::ValuesIn({ false, true })));
 
 }  // namespace pono_tests


### PR DESCRIPTION
This PR introduces an alternative approach for abstracting bit-vector arithmetic operations using free state symbols.
Compared to using uninterpreted functions, this abstraction is coarser (less precise).
The CEGAR implementation can be shared between the two abstraction methods.

The table below summarizes the number of solved tasks on a benchmark set of IC3IA/IC3SA with and without abstraction ([more info](https://www.cip.ifi.lmu.de/~chien/benchexec-results/pono/0.1.1-274-g5203f52/cegbv.uf-vs-free-var.table.html)):

|       | cegbv (free var) | default | diff    | cegbv (uf) | diff    |
|-------|------------------|---------|---------|------------|---------|
| IC3IA |              751 |     735 | +30/-14 |        750 | +14/-13 |
| IC3SA |              731 |     732 | +21/-22 |        736 | +15/-20 |

The results indicate that this new abstraction is able to solve certain tasks that the previous approach could not.