### PR TITLE
Update the name of Boolector build script

### DIFF
--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -82,7 +82,7 @@ if [ ! -d "$DEPS/smt-switch" ]; then
         ./contrib/setup-cvc5.sh
     fi
     if [ $WITH_BOOLECTOR = ON ]; then
-        ./contrib/setup-btor.sh
+        ./contrib/setup-boolector.sh
     fi
     # pass bison/flex directories from smt-switch perspective
     ./configure.sh --bitwuzla --cvc5 $CONF_OPTS --prefix=local --static --smtlib-reader --bison-dir=../bison/bison-install --flex-dir=../flex/flex-install


### PR DESCRIPTION
The script was renamed in https://github.com/stanford-centaur/smt-switch/commit/dde2e0412dd492fdf87b942e8116f65120b37637.