### PR TITLE
Unroll formulas at step 0 of ISMC

### DIFF
--- a/engines/interp_seq_mc.cpp
+++ b/engines/interp_seq_mc.cpp
@@ -178,8 +178,10 @@ bool InterpSeqMC::step(int i)
 bool InterpSeqMC::step_0()
 {
   solver_->reset_assertions();
-  solver_->assert_formula(reach_seq_.at(0));
-  solver_->assert_formula(bad_);
+  // push the unrolled formulas here
+  // as compute_witness() rely on timed variables
+  solver_->assert_formula(unroller_.at_time(reach_seq_.at(0), 0));
+  solver_->assert_formula(unroller_.at_time(bad_, 0));
 
   Result r = solver_->check_sat();
   if (r.is_unsat()) {

--- a/engines/interp_seq_mc.h
+++ b/engines/interp_seq_mc.h
@@ -59,7 +59,7 @@ class InterpSeqMC : public SafetyProver
   // set to true when a concrete_cex is found
   bool concrete_cex_;
 
-  // reachability sequence: <Init, R_0, R_1, ...>
+  // reachability sequence: <R_0=Init, R_1, R_2, ...>
   smt::TermVec reach_seq_;
   // transition at each time step: <Init(0) & TR(0, 1), TR(1, 2), ...>
   // note that at 0th step, Init is conjoined with TR


### PR DESCRIPTION
At step 0 of ISMC, we check the satisfiability of $Init(s) \wedge \neg P(s)$.
The untimed and timed versions of the formula are equisatisfiable.
However, to compute the witness with `compute_witness()`, the variables have to be timed.