### PR TITLE
Store concrete CEX from the failing refinment query of CEGAR BV-arith

### DIFF
--- a/engines/cegar_ops_uf.cpp
+++ b/engines/cegar_ops_uf.cpp
@@ -149,6 +149,8 @@ bool CegarOpsUf<Prover_T>::cegar_refine()
 {
   const UnorderedTermMap & abs_terms = oa_.abstract_terms();
   if (abs_terms.size() == 0) {
+    // no abstraction, let prover compute witness
+    Prover_T::compute_witness();
     return false;
   }
 

--- a/engines/cegar_ops_uf.cpp
+++ b/engines/cegar_ops_uf.cpp
@@ -52,6 +52,8 @@ CegarOpsUf<Prover_T>::CegarOpsUf(const SafetyProperty & p,
       cegopsuf_un_(cegopsuf_ts_)
 {
   cegopsuf_solver_->set_opt("produce-unsat-assumptions", "true");
+
+  // store the original ts for later use in witness generation
   super::orig_ts_ = ts;
 }
 

--- a/engines/cegar_ops_uf.h
+++ b/engines/cegar_ops_uf.h
@@ -46,6 +46,8 @@ class CegarOpsUf : public CEGAR<Prover_T>
 
   bool cegar_refine() override;
 
+  void store_witness();
+
   void refine_subprover_ts_base(const smt::UnorderedTermSet & axioms,
                                 bool skip_init);
   void refine_subprover_ts(const smt::UnorderedTermSet & axioms,

--- a/engines/cegar_ops_uf.h
+++ b/engines/cegar_ops_uf.h
@@ -46,6 +46,15 @@ class CegarOpsUf : public CEGAR<Prover_T>
 
   bool cegar_refine() override;
 
+  /**
+   * Extract the SAT assignment from the latest refine query,
+   * transfer the terms to the prover's solver, and
+   * store them in the prover's `witness_` field.
+   *
+   * We deliberately do not override the prover's `compute_witness`
+   * method, because it may be called by the prover's `check_until`
+   * method, which is called in each CEGAR iteration.
+   */
   void store_witness();
 
   void refine_subprover_ts_base(const smt::UnorderedTermSet & axioms,


### PR DESCRIPTION
This PR adds a `store_witness` method to the `CegarOpsUf` class, which extracts state and input values from the SAT refinement query.