### PR TITLE
Enable BV index sort in CEGP

### DIFF
--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -10,7 +10,8 @@
 ** directory for licensing information.\endverbatim
 **
 ** \brief An implementation of Counter-Example Guided Prophecy for array
-**        model checking. It is parameterized by an underlying model checking
+**        model checking (https://lmcs.episciences.org/9984/pdf).
+**        It is parameterized by an underlying model checking
 **        procedure which need not handle arrays (only UF). However, a common
 **        instantiation is with an IC3-style procedure, in which case we
 **        often refer to this algorithm as "prophic3".
@@ -87,8 +88,15 @@ ProverResult CegProphecyArrays<MsatIC3IA>::prove()
     // heuristic -- stop refining when no new axioms are needed.
     do {
       if (!CegProphecyArrays::cegar_refine()) {
-        // real counterexample
-        return ProverResult::FALSE;
+        if (has_finite_index_sort_) {
+          // Havoc the result to UNKNOWN because we ignore the lambda axioms
+          // for finite-domain index sort, and this may lead to false alarms
+          // (see p17 of CEGP paper).
+          // TODO: perform BMC on concrete TS and extract witness
+          return ProverResult::UNKNOWN;
+        } else {
+          return ProverResult::FALSE;
+        }
       }
       reached_k_++;
     } while (num_added_axioms_);
@@ -139,7 +147,15 @@ ProverResult CegProphecyArrays<Prover_T>::check_until(int k)
     // heuristic -- stop refining when no new axioms are needed.
     do {
       if (!CegProphecyArrays::cegar_refine()) {
-        return ProverResult::FALSE;
+        if (has_finite_index_sort_) {
+          // Havoc the result to UNKNOWN because we ignore the lambda axioms
+          // for finite-domain index sort, and this may lead to false alarms
+          // (see p17 of CEGP paper).
+          // TODO: perform BMC on concrete TS and extract witness
+          return ProverResult::UNKNOWN;
+        } else {
+          return ProverResult::FALSE;
+        }
       }
       reached_k_++;
     } while (num_added_axioms_ && reached_k_ <= k);

--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -252,7 +252,7 @@ void CegProphecyArrays<Prover_T>::initialize()
       SortKind sk = sort->get_indexsort()->get_sort_kind();
       if (sk == REAL || sk == INT) {
         // do nothing
-      } else if (sk == BV) {
+      } else if (sk == BV || sk == BOOL) {
         has_finite_index_sort_ = true;
       } else {
         throw PonoException("CEGP: unhandled index sort in array: "
@@ -268,7 +268,7 @@ void CegProphecyArrays<Prover_T>::initialize()
       SortKind sk = sort->get_indexsort()->get_sort_kind();
       if (sk == REAL || sk == INT) {
         // do nothing
-      } else if (sk == BV) {
+      } else if (sk == BV || sk == BOOL) {
         has_finite_index_sort_ = true;
       } else {
         throw PonoException("CEGP: unhandled index sort in array: "

--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -226,6 +226,7 @@ void CegProphecyArrays<Prover_T>::initialize()
   super::initialize();
 
   bool contains_arrays = false;
+  has_finite_index_sort_ = false;
   Sort boolsort = super::solver_->make_sort(BOOL);
   Sort sort;
   for (const auto & sv : conc_ts_.statevars()) {
@@ -233,8 +234,13 @@ void CegProphecyArrays<Prover_T>::initialize()
     if (sort->get_sort_kind() == ARRAY) {
       contains_arrays = true;
       SortKind sk = sort->get_indexsort()->get_sort_kind();
-      if (sk != REAL && sk != INT) {
+      if (sk == REAL || sk == INT) {
+        // do nothing
+      } else if (sk == BV) {
         has_finite_index_sort_ = true;
+      } else {
+        throw PonoException("CEGP: unhandled index sort in array: "
+                            + to_string(sk));
       }
     }
   }
@@ -244,8 +250,13 @@ void CegProphecyArrays<Prover_T>::initialize()
     if (sort->get_sort_kind() == ARRAY) {
       contains_arrays = true;
       SortKind sk = sort->get_indexsort()->get_sort_kind();
-      if (sk != REAL && sk != INT) {
+      if (sk == REAL || sk == INT) {
+        // do nothing
+      } else if (sk == BV) {
         has_finite_index_sort_ = true;
+      } else {
+        throw PonoException("CEGP: unhandled index sort in array: "
+                            + to_string(sk));
       }
     }
   }

--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -232,13 +232,13 @@ void CegProphecyArrays<Prover_T>::initialize()
     sort = sv->get_sort();
     if (sort->get_sort_kind() == ARRAY) {
       contains_arrays = true;
-      SortKind sk = sort->get_indexsort()->get_sort_kind();
-      if (sk != REAL && sk != INT) {
-        throw PonoException(
-            "CEGP currently only supports infinite domain indices in arrays "
-            "due to an edge case for constant arrays, but got "
-            + sort->to_string());
-      }
+      // SortKind sk = sort->get_indexsort()->get_sort_kind();
+      // if (sk != REAL && sk != INT) {
+      //   throw PonoException(
+      //       "CEGP currently only supports infinite domain indices in arrays "
+      //       "due to an edge case for constant arrays, but got "
+      //       + sort->to_string());
+      // }
     }
   }
 
@@ -246,13 +246,13 @@ void CegProphecyArrays<Prover_T>::initialize()
     sort = iv->get_sort();
     if (sort->get_sort_kind() == ARRAY) {
       contains_arrays = true;
-      SortKind sk = sort->get_indexsort()->get_sort_kind();
-      if (sk != REAL && sk != INT) {
-        throw PonoException(
-            "CEGP currently only supports infinite domain indices in arrays "
-            "due to an edge case for constant arrays, but got "
-            + sort->to_string());
-      }
+      // SortKind sk = sort->get_indexsort()->get_sort_kind();
+      // if (sk != REAL && sk != INT) {
+      //   throw PonoException(
+      //       "CEGP currently only supports infinite domain indices in arrays "
+      //       "due to an edge case for constant arrays, but got "
+      //       + sort->to_string());
+      // }
     }
   }
 

--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -232,13 +232,10 @@ void CegProphecyArrays<Prover_T>::initialize()
     sort = sv->get_sort();
     if (sort->get_sort_kind() == ARRAY) {
       contains_arrays = true;
-      // SortKind sk = sort->get_indexsort()->get_sort_kind();
-      // if (sk != REAL && sk != INT) {
-      //   throw PonoException(
-      //       "CEGP currently only supports infinite domain indices in arrays "
-      //       "due to an edge case for constant arrays, but got "
-      //       + sort->to_string());
-      // }
+      SortKind sk = sort->get_indexsort()->get_sort_kind();
+      if (sk != REAL && sk != INT) {
+        has_finite_index_sort_ = true;
+      }
     }
   }
 
@@ -246,13 +243,10 @@ void CegProphecyArrays<Prover_T>::initialize()
     sort = iv->get_sort();
     if (sort->get_sort_kind() == ARRAY) {
       contains_arrays = true;
-      // SortKind sk = sort->get_indexsort()->get_sort_kind();
-      // if (sk != REAL && sk != INT) {
-      //   throw PonoException(
-      //       "CEGP currently only supports infinite domain indices in arrays "
-      //       "due to an edge case for constant arrays, but got "
-      //       + sort->to_string());
-      // }
+      SortKind sk = sort->get_indexsort()->get_sort_kind();
+      if (sk != REAL && sk != INT) {
+        has_finite_index_sort_ = true;
+      }
     }
   }
 
@@ -287,7 +281,8 @@ bool CegProphecyArrays<Prover_T>::cegar_refine()
   Term abs_bmc_formula = get_bmc_formula(reached_k_ + 1);
 
   // check array axioms over the abstract system
-  if (!aae_.enumerate_axioms(abs_bmc_formula, reached_k_ + 1)) {
+  if (!aae_.enumerate_axioms(
+          abs_bmc_formula, reached_k_ + 1, true, has_finite_index_sort_)) {
     // concrete CEX
     return false;
   }
@@ -374,7 +369,8 @@ bool CegProphecyArrays<Prover_T>::cegar_refine()
     abs_bmc_formula = get_bmc_formula(reached_k_ + 1);
 
     // search for axioms again but don't include nonconsecutive ones
-    bool ok = aae_.enumerate_axioms(abs_bmc_formula, reached_k_ + 1, false);
+    bool ok = aae_.enumerate_axioms(
+        abs_bmc_formula, reached_k_ + 1, false, has_finite_index_sort_);
     // should be guaranteed to rule out counterexamples at this bound
     assert(ok);
     consecutive_axioms = aae_.get_consecutive_axioms();

--- a/engines/ceg_prophecy_arrays.h
+++ b/engines/ceg_prophecy_arrays.h
@@ -73,6 +73,9 @@ class CegProphecyArrays : public CEGAR<Prover_T>
       important_vars_;  ///< important variables
                         ///< useful for IC3IA to prioritize predicates
 
+  // whether the arrays in the system has a finite index sort
+  bool has_finite_index_sort_ = false;
+
   TransitionSystem & prover_interface_ts() override { return conc_ts_; }
 
   void cegar_abstract() override;

--- a/engines/ceg_prophecy_arrays.h
+++ b/engines/ceg_prophecy_arrays.h
@@ -10,7 +10,8 @@
 ** directory for licensing information.\endverbatim
 **
 ** \brief An implementation of Counter-Example Guided Prophecy for array
-**        model checking. It is parameterized by an underlying model checking
+**        model checking (https://lmcs.episciences.org/9984/pdf).
+**        It is parameterized by an underlying model checking
 **        procedure which need not handle arrays (only UF). However, a common
 **        instantiation is with an IC3-style procedure, in which case we
 **        often refer to this algorithm as "prophic3".

--- a/refiners/array_axiom_enumerator.cpp
+++ b/refiners/array_axiom_enumerator.cpp
@@ -159,6 +159,15 @@ bool ArrayAxiomEnumerator::enumerate_axioms(const Term & abs_trace_formula,
                                             size_t bound,
                                             bool include_nonconsecutive)
 {
+  return enumerate_axioms(
+      abs_trace_formula, bound, include_nonconsecutive, false);
+}
+
+bool ArrayAxiomEnumerator::enumerate_axioms(const Term & abs_trace_formula,
+                                            size_t bound,
+                                            bool include_nonconsecutive,
+                                            bool skip_lambda_axioms)
+{
   assert(initialized_);
 
   // IMPORTANT: clear state from last run
@@ -193,15 +202,21 @@ bool ArrayAxiomEnumerator::enumerate_axioms(const Term & abs_trace_formula,
 
     // experimenting with new heuristic order
     found_lemmas |= check_consecutive_axioms(ARRAYEQ_READ, only_curr);
-    found_lemmas |= check_consecutive_axioms(ARRAYEQ_READ_LAMBDA, only_curr);
+    if (!skip_lambda_axioms) {
+      found_lemmas |= check_consecutive_axioms(ARRAYEQ_READ_LAMBDA, only_curr);
+    }
     found_lemmas |= check_consecutive_axioms(STORE_WRITE, only_curr);
     found_lemmas |= check_consecutive_axioms(STORE_READ, only_curr);
-    found_lemmas |= check_consecutive_axioms(STORE_READ_LAMBDA, only_curr);
+    if (!skip_lambda_axioms) {
+      found_lemmas |= check_consecutive_axioms(STORE_READ_LAMBDA, only_curr);
+    }
     found_lemmas |= check_consecutive_axioms(CONSTARR, only_curr);
-    found_lemmas |= check_consecutive_axioms(CONSTARR_LAMBDA, only_curr);
+    if (!skip_lambda_axioms) {
+      found_lemmas |= check_consecutive_axioms(CONSTARR_LAMBDA, only_curr);
+    }
     found_lemmas |= check_consecutive_axioms(ARRAYEQ_WITNESS, only_curr);
 
-    if (!found_lemmas) {
+    if (!found_lemmas && !skip_lambda_axioms) {
       // NOTE: don't need non-consecutive version of these axioms
       //       all different over current and next is sufficient to be all
       //       different for all time

--- a/refiners/array_axiom_enumerator.h
+++ b/refiners/array_axiom_enumerator.h
@@ -86,6 +86,11 @@ class ArrayAxiomEnumerator : public AxiomEnumerator
                         size_t bound,
                         bool include_nonconsecutive = true) override;
 
+  bool enumerate_axioms(const smt::Term & abs_trace_formula,
+                        size_t bound,
+                        bool include_nonconsecutive,
+                        bool skip_lambda_axioms);
+
   /** Add a new index to the index set
    *  This can happen as we add auxiliary variables
    *  In particular, prophecy variables that are added here


### PR DESCRIPTION
This PR implements the "low-effort" approach for BV indices as described in the [CEGP paper](https://lmcs.episciences.org/9984/pdf):

> One low-effort approach for applying counterexample-guided prophecy over finite-domain indices is to give up completeness. By simply not including axioms over a λ index for finite-domain sorts, the array solving procedure might conclude the query is satisfiable when it is actually unsatisfiable. Thus, the overall algorithm could return spurious counterexamples, but would still soundly return proofs. A given spurious counterexample is finite and would be straightforward to analyze, either with a dedicated checker or an SMT solver without this limitation.

If no further refinement can be made, the results are havocked from `FALSE` to `UNKNOWN` to avoid spurious counterexamples.

A preliminary evaluation is done on 1521 Btor2 tasks with arrays.
The [results](https://www.cip.ifi.lmu.de/~chien/benchexec-results/pono/0.1.1-290-g8527afd/cegp-bv-index.table.html) show that [`cegp+ic3ia`](https://www.cip.ifi.lmu.de/~chien/benchexec-results/pono/0.1.1-290-g8527afd/cegp-bv-index.table.html#/table?hidden=2,3&hidden0=2,4&hidden1=2,4&hidden4=2,4&filter=0(0*status*(status(notIn()),category(notIn()))),1(0*status*(status(notIn()),category(in(correct)))),4(0*status*(status(notIn()),category(in(error))))) and [`cegp+interp`](https://www.cip.ifi.lmu.de/~chien/benchexec-results/pono/0.1.1-290-g8527afd/cegp-bv-index.table.html#/table?hidden=0,1&hidden0=2,4&hidden1=2,4&hidden4=2,4&hidden2=2,4&hidden3=2,4&filter=2(0*status*(status(notIn()),category(notIn()))),3(0*status*(status(notIn()),category(in(correct)))),4(0*status*(status(notIn()),category(in(error))))) could solve some tasks that `ind` could not.

Related to #271.