### PR TITLE
Don't error on getting unknown from solver

### DIFF
--- a/engines/interp_seq_mc.cpp
+++ b/engines/interp_seq_mc.cpp
@@ -22,7 +22,6 @@
 #include "smt-switch/utils.h"
 #include "smt/available_solvers.h"
 #include "utils/logger.h"
-#include "utils/term_analysis.h"
 
 using namespace smt;
 
@@ -172,10 +171,14 @@ bool InterpSeqMC::step(int i)
       // replay it in the solver with model generation
       concrete_cex_ = true;
     } else if (r.is_sat() && !bmc_res.is_sat()) {
-      throw PonoException("Internal error: Expecting satisfiable result");
+      if (bmc_res.is_unsat()) {
+        throw PonoException("expecting satisfiable result");
+      } else {
+        throw InternalSolverException("solver could not compute BMC query");
+      }
     } else {
-      throw PonoException("Interpolation failed due to: "
-                          + r.get_explanation());
+      throw InternalSolverException("interpolation failed due to: "
+                                    + r.get_explanation());
     }
     return false;
   }

--- a/engines/interpolantmc.cpp
+++ b/engines/interpolantmc.cpp
@@ -108,7 +108,7 @@ ProverResult InterpolantMC::check_until(int k)
     }
   }
   catch (InternalSolverException & e) {
-    logger.log(1, "Failed when computing interpolant.");
+    logger.log(1, "solver call failed: {}", e.what());
   }
   return ProverResult::UNKNOWN;
 }
@@ -184,13 +184,15 @@ bool InterpolantMC::step(const int i)
           And, init0_, solver_->make_term(And, solver_trans, bad_i)));
 
       Result r = solver_->check_sat();
-      if (!r.is_sat()) {
+      if (r.is_unsat()) {
         throw PonoException("Internal error: Expecting satisfiable result");
+      } else {
+        throw InternalSolverException("solver could not compute concrete cex");
       }
       return false;
     } else if (r.is_unknown()) {
       // TODO: figure out if makes sense to increase bound and try again
-      throw PonoException("Interpolant generation failed.");
+      throw InternalSolverException("interpolant generation failed");
     }
   }
 


### PR DESCRIPTION
Bitwuzla (and other solvers) can return "unknown" when they can't compute an interpolant or encounter equality between constant arrays. We should handle this more gracefully by returning "unknown" instead of "error."