### PR TITLE
Move EXCLUDE_FROM_ALL from individual test targets to test subdir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,7 +323,7 @@ enable_testing()
 # Add tests subdirectory
 # The CMakeLists.txt file there sets up googletest
 # and builds all the parametrized tests
-add_subdirectory(tests)
+add_subdirectory(tests EXCLUDE_FROM_ALL)
 
 add_executable(pono-bin "${PROJECT_SOURCE_DIR}/pono.cpp")
 set_target_properties(pono-bin PROPERTIES OUTPUT_NAME pono)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,7 +48,7 @@ target_link_libraries(pono-test-lib pono-lib)
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
 
 macro(pono_add_test name)
-  add_executable(${name} EXCLUDE_FROM_ALL "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cpp")
+  add_executable(${name} "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cpp")
   target_link_libraries(${name} gtest gtest_main)
   target_link_libraries(${name} pono-test-lib) # also includes pono-lib because it's linked
   add_dependencies(check ${name})


### PR DESCRIPTION
This way the `tests/all` target can be used to just rebuild the tests.