### PR TITLE
parallel portfolio: Increase default bound

### DIFF
--- a/scripts/parallel_pono.py
+++ b/scripts/parallel_pono.py
@@ -128,7 +128,7 @@ def main() -> int:
     parser.add_argument("btor_file", help="input benchmark in BTOR2 format")
     parser.add_argument("witness_file", nargs="?", help="file to store the witness in")
     parser.add_argument(
-        "-k", "--bound", default=1000, type=int, help="bound to check until"
+        "-k", "--bound", default=2**20, type=int, help="bound to check until"
     )
     parser.add_argument("-v", "--verbose", action="store_true", help="echo stderr")
     parser.add_argument(


### PR DESCRIPTION
Ideally the default in pono is unbounded, but until then we should increase the one passed by the portfolio script.