### PR TITLE
Fix Relational Transition Systems soundness bugs

### DIFF
--- a/core/rts.cpp
+++ b/core/rts.cpp
@@ -59,7 +59,7 @@ void RelationalTransitionSystem::set_updated_states(const smt::Term & term)
   if (curr != curr_map_.end()) {
     no_state_updates_.erase(curr->second);
   }
-  for (const auto& subTerm : *term) {
+  for (const auto & subTerm : *term) {
     set_updated_states(subTerm);
   }
 }

--- a/core/rts.cpp
+++ b/core/rts.cpp
@@ -30,6 +30,7 @@ void RelationalTransitionSystem::set_behavior(const Term & init,
   }
   init_ = init;
   trans_ = trans;
+  set_updated_states(trans_);
 }
 
 void RelationalTransitionSystem::set_trans(const Term & trans)
@@ -39,6 +40,7 @@ void RelationalTransitionSystem::set_trans(const Term & trans)
     throw PonoException("Unknown symbols");
   }
   trans_ = trans;
+  set_updated_states(trans_);
 }
 
 void RelationalTransitionSystem::constrain_trans(const Term & constraint)
@@ -48,6 +50,17 @@ void RelationalTransitionSystem::constrain_trans(const Term & constraint)
     throw PonoException("Unknown symbols");
   }
   trans_ = solver_->make_term(And, trans_, constraint);
+  set_updated_states(constraint);
 }
 
+void RelationalTransitionSystem::set_updated_states(const smt::Term & term)
+{
+  auto curr = curr_map_.find(term);
+  if (curr != curr_map_.end()) {
+    no_state_updates_.erase(curr->second);
+  }
+  for (const auto& subTerm : *term) {
+    set_updated_states(subTerm);
+  }
+}
 }  // namespace pono

--- a/core/rts.h
+++ b/core/rts.h
@@ -57,7 +57,7 @@ class RelationalTransitionSystem : public TransitionSystem
   void constrain_trans(const smt::Term & constraint);
 
  private:
-  /* Finds all state variables referenced in some 'next' transition inside 
+  /* Finds all state variables referenced in some 'next' transition inside
    * 'term' and marks them as updated states in the TransitionSystem
    */
   void set_updated_states(const smt::Term & term);

--- a/core/rts.h
+++ b/core/rts.h
@@ -55,6 +55,12 @@ class RelationalTransitionSystem : public TransitionSystem
    * @param constraint new constraint on transition relation
    */
   void constrain_trans(const smt::Term & constraint);
+
+ private:
+  /* Finds all state variables referenced in some 'next' transition inside 
+   * 'term' and marks them as updated states in the TransitionSystem
+   */
+  void set_updated_states(const smt::Term & term);
 };
 
 }  // namespace pono

--- a/core/ts.cpp
+++ b/core/ts.cpp
@@ -197,7 +197,9 @@ void TransitionSystem::assign_next(const Term & state, const Term & val)
 
   state_updates_[state] = val;
   auto erased = no_state_updates_.erase(state);
-  assert(erased);
+  // Relational transition systems might have marked the state as updated
+  // outside 'assign_next', so don't require them to erase here.
+  assert(!functional_ || erased);
   trans_ = solver_->make_term(
       And, trans_, solver_->make_term(Equal, next_map_.at(state), val));
 

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -293,7 +293,9 @@ Term KInduction::simple_path_constraint(int i, int j)
     disj = solver_->make_term(PrimOp::Or, disj, neq);
   }
   // add selector term
-  disj = solver_->make_term(PrimOp::Or, disj, sel_simple_path_terms_);
+  if (disj != false_) {
+    disj = solver_->make_term(PrimOp::Or, disj, sel_simple_path_terms_);
+  }
 
   return disj;
 }
@@ -310,9 +312,11 @@ bool KInduction::check_simple_path_eager(int i)
   // solver call below for inductive case check
   for (int j = 0; (!no_simp_path_check && j < i); j++) {
     Term constraint = simple_path_constraint(j, i);
-    kind_log_msg(
-        3, "   ", "adding simple path clause for pair 'j,i' = {},{}", j, i);
-    solver_->assert_formula(constraint);
+    if (constraint != false_) {
+      kind_log_msg(
+          3, "   ", "adding simple path clause for pair 'j,i' = {},{}", j, i);
+      solver_->assert_formula(constraint);
+    }
   }
 
   // Note: the solver call here is actually not necessary since we add
@@ -368,7 +372,7 @@ bool KInduction::check_simple_path_lazy(int i)
         Term constraint = simple_path_constraint(j, l);
         kind_log_msg(
             3, "    ", "checking constraint for pair j,l = {} , {}", j, l);
-        if (solver_->get_value(constraint) == false_) {
+        if (constraint != false_ && solver_->get_value(constraint) == false_) {
           kind_log_msg(
               3, "      ", "adding constraint for pair j,l = {} , {}", j, l);
           added_to_simple_path = true;


### PR DESCRIPTION
Since Relational Transition Systems might have their state transitions set without calling TransitionSystem::assign_next, valid states would be incorrectly marked as not having any transitions (by remaining into the "TransitionSystem::no_state_updates_" set).

This caused incorrect proven results on BMC-SP and k-induction engines. Fixed by traversing the transition constrain in RTS and ensuring that all state variables are removed from "no_state_updates_".

I'm adding test cases covering this fix in a separate pull request because the SMV inputs reproducing the bug depend on other SMV frontend enhancements.