### PR TITLE
Add optional IC3Bits partial-model predecessor generalization

### DIFF
--- a/engines/ic3bits.cpp
+++ b/engines/ic3bits.cpp
@@ -23,6 +23,7 @@
 #include "smt-switch/smt.h"
 #include "smt-switch/utils.h"
 #include "utils/exceptions.h"
+#include "utils/partial_model.h"
 
 using namespace smt;
 
@@ -33,7 +34,9 @@ IC3Bits::IC3Bits(const SafetyProperty & p,
                  const SmtSolver & solver,
                  PonoOptions opt,
                  Engine engine)
-    : super(p, ts, solver, opt, engine)
+    : super(p, ts, solver, opt, engine),
+      partial_model_getter_(solver_),
+      has_assumptions_(false)
 {
 }
 
@@ -44,6 +47,22 @@ void IC3Bits::initialize()
   }
 
   super::initialize();
+
+  build_ts_related_info();
+
+  // Constraints live over current/no-next terms. Include each constraint and
+  // its next-state update rewritten back to current variables when computing
+  // the predecessor's relevant bit slices.
+  assert(!nxt_state_updates_.empty());
+  for (const auto & c_initnext : ts_.constraints()) {
+    has_assumptions_ = true;
+    assert(ts_.no_next(c_initnext.first));
+    constraints_curr_var_.emplace(
+        c_initnext.first, std::vector<std::pair<int, int>>({ { 0, 0 } }));
+    constraints_curr_var_.emplace(
+        next_curr_replace(ts_.next(c_initnext.first)),
+        std::vector<std::pair<int, int>>({ { 0, 0 } }));
+  }
 
   Term bv1 = solver_->make_term(1, solver_->make_sort(BV, 1));
 
@@ -58,6 +77,22 @@ void IC3Bits::initialize()
         state_bits_.push_back(solver_->make_term(
             Equal, solver_->make_term(Op(Extract, i, i), sv), bv1));
       }
+    }
+  }
+}
+
+void IC3Bits::build_ts_related_info()
+{
+  // nxt_state_updates_ rewrites primed state variables to their next-state
+  // functions. State variables without updates are treated like inputs and are
+  // omitted from partial predecessors unless assumptions force keeping them.
+  const auto & state_updates = ts_.state_updates();
+  for (const auto & sv : ts_.statevars()) {
+    auto pos = state_updates.find(sv);
+    if (pos == state_updates.end()) {
+      no_next_vars_.insert(sv);
+    } else {
+      nxt_state_updates_.emplace(ts_.next(sv), pos->second);
     }
   }
 }
@@ -109,6 +144,77 @@ void IC3Bits::check_ts() const
                             + to_string(sort->get_sort_kind()));
       }
     }
+  }
+}
+
+bool IC3Bits::keep_var_in_partial_model(const Term & v) const
+{
+  // With constraints, input/no-next variables can affect enabled transitions,
+  // so keep all current variables. Otherwise restrict cubes to updated state.
+  if (has_assumptions_) {
+    return ts_.is_curr_var(v);
+  }
+
+  return ts_.is_curr_var(v) && no_next_vars_.find(v) == no_next_vars_.end();
+}
+
+IC3Formula IC3Bits::ExtractPartialModel(const Term & p)
+{
+  assert(ts_.no_next(p));
+
+  std::unordered_map<Term, std::vector<std::pair<int, int>>> varlist;
+  // IC3 gives a current-state bad predicate. To compute a predecessor cube,
+  // move it through the next-state functions and then analyze the result over
+  // current variables.
+  Term bad_state_no_nxt = next_curr_replace(ts_.next(p));
+
+  if (has_assumptions_) {
+    auto ast_slices = constraints_curr_var_;
+    ast_slices.emplace(bad_state_no_nxt,
+                       std::vector<std::pair<int, int>>({ { 0, 0 } }));
+    partial_model_getter_.GetVarListForAsts_in_bitlevel(ast_slices, varlist);
+  } else {
+    std::unordered_map<Term, std::vector<std::pair<int, int>>> in_ast;
+    in_ast.emplace(bad_state_no_nxt,
+                   std::vector<std::pair<int, int>>({ { 0, 0 } }));
+    partial_model_getter_.GetVarListForAsts_in_bitlevel(in_ast, varlist);
+  }
+
+  TermVec conjvec_partial;
+  for (const auto & v_slice_pair : varlist) {
+    const auto & v = v_slice_pair.first;
+    if (!keep_var_in_partial_model(v)) continue;
+
+    Term val = solver_->get_value(v);
+    if (v->get_sort() == boolsort_) {
+      // Boolean variables are already single-bit terms; Extract is only valid
+      // for bit-vectors.
+      conjvec_partial.push_back(solver_->make_term(Op(Equal), v, val));
+      continue;
+    }
+
+    for (const auto & h_l_pair : v_slice_pair.second) {
+      for (int idx = h_l_pair.first; idx >= h_l_pair.second; --idx) {
+        auto eq = solver_->make_term(
+            Op(Equal),
+            solver_->make_term(Op(Extract, idx, idx), v),
+            solver_->make_term(Op(Extract, idx, idx), val));
+        conjvec_partial.push_back(eq);
+      }
+    }
+  }
+
+  if (conjvec_partial.empty()) conjvec_partial.push_back(solver_true_);
+  return ic3formula_conjunction(conjvec_partial);
+}
+
+void IC3Bits::predecessor_generalization(size_t i,
+                                         const Term & cterm,
+                                         IC3Formula & pred)
+{
+  (void)i;
+  if (options_.ic3_pregen_) {
+    pred = ExtractPartialModel(cterm);
   }
 }
 

--- a/engines/ic3bits.cpp
+++ b/engines/ic3bits.cpp
@@ -212,10 +212,14 @@ void IC3Bits::predecessor_generalization(size_t i,
                                          const Term & cterm,
                                          IC3Formula & pred)
 {
-  (void)i;
-  if (options_.ic3_pregen_) {
+  if (!options_.ic3_pregen_) return;
+
+  if (options_.ic3bits_partial_model_pregen_) {
     pred = ExtractPartialModel(cterm);
+    return;
   }
+
+  IC3::predecessor_generalization(i, cterm, pred);
 }
 
 }  // namespace pono

--- a/engines/ic3bits.h
+++ b/engines/ic3bits.h
@@ -21,6 +21,7 @@
 #include "engines/ic3.h"
 #include "options/options.h"
 #include "smt-switch/smt.h"
+#include "utils/partial_model.h"
 
 namespace pono {
 
@@ -43,6 +44,13 @@ class IC3Bits : public IC3
   smt::TermVec state_bits_;  ///< boolean variables + bit-vector variables
                              ///< split into individual bits
 
+  PartialModelGen partial_model_getter_;
+  bool has_assumptions_;
+  smt::UnorderedTermMap nxt_state_updates_;
+  smt::UnorderedTermSet no_next_vars_;
+  std::unordered_map<smt::Term, std::vector<std::pair<int, int>>>
+      constraints_curr_var_;
+
   // virtual method overrides
 
   IC3Formula get_model_ic3formula() const override;
@@ -50,6 +58,21 @@ class IC3Bits : public IC3
   bool ic3formula_check_valid(const IC3Formula & u) const override;
 
   void check_ts() const override;
+
+  bool keep_var_in_partial_model(const smt::Term & v) const;
+
+  void build_ts_related_info();
+
+  smt::Term next_curr_replace(const smt::Term & in) const
+  {
+    return ts_.solver()->substitute(in, nxt_state_updates_);
+  }
+
+  void predecessor_generalization(size_t i,
+                                  const smt::Term & c,
+                                  IC3Formula & pred) override;
+
+  IC3Formula ExtractPartialModel(const smt::Term & p);
 };
 
 }  // namespace pono

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -68,6 +68,7 @@ enum optionIndex
   IC3_GEN_MAX_ITER,
   IC3_FUNCTIONAL_PREIMAGE,
   NO_IC3_UNSATCORE_GEN,
+  IC3BITS_PARTIAL_MODEL_PREGEN,
   NO_IC3IA_REDUCE_PREDS,
   NO_IC3IA_TRACK_IMPORTANT_VARS,
   NO_IC3IA_SIM_CEX,
@@ -391,6 +392,14 @@ const option::Descriptor usage[] = {
     "variants but also runs the risk of myopic over-generalization. Some IC3 "
     "variants have better inductive generalization and do better with this "
     "option." },
+  { IC3BITS_PARTIAL_MODEL_PREGEN,
+    0,
+    "",
+    "ic3bits-partial-model-pregen",
+    Arg::None,
+    "  --ic3bits-partial-model-pregen \tUse bit-level partial-model "
+    "predecessor generalization in IC3Bits instead of the parent Boolean IC3 "
+    "predecessor generalization." },
   { NO_IC3IA_REDUCE_PREDS,
     0,
     "",
@@ -950,6 +959,9 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
           break;
         case IC3_FUNCTIONAL_PREIMAGE: ic3_functional_preimage_ = true; break;
         case NO_IC3_UNSATCORE_GEN: ic3_unsatcore_gen_ = false; break;
+        case IC3BITS_PARTIAL_MODEL_PREGEN:
+          ic3bits_partial_model_pregen_ = true;
+          break;
         case NO_IC3IA_REDUCE_PREDS: ic3ia_reduce_preds_ = false;
         case NO_IC3IA_TRACK_IMPORTANT_VARS: ic3ia_track_important_vars_ = false;
         case NO_IC3IA_SIM_CEX: ic3ia_sim_cex_ = false; break;

--- a/options/options.h
+++ b/options/options.h
@@ -147,6 +147,7 @@ class PonoOptions
         mbic3_indgen_mode(default_mbic3_indgen_mode),
         ic3_functional_preimage_(default_ic3_functional_preimage_),
         ic3_unsatcore_gen_(default_ic3_unsatcore_gen_),
+        ic3bits_partial_model_pregen_(default_ic3bits_partial_model_pregen_),
         ic3ia_reduce_preds_(default_ic3ia_reduce_preds_),
         ic3ia_track_important_vars_(default_ic3ia_track_important_vars_),
         ic3ia_sim_cex_(default_ic3ia_sim_cex_),
@@ -264,6 +265,7 @@ class PonoOptions
   bool ic3_functional_preimage_;    ///< functional preimage in IC3
   bool ic3_unsatcore_gen_;  ///< generalize a cube during relative inductiveness
                             ///< check with unsatcore
+  bool ic3bits_partial_model_pregen_;  ///< use partial-model pregen in IC3Bits
   bool ic3ia_reduce_preds_;  ///< reduce predicates with unsatcore in IC3IA
   bool ic3ia_track_important_vars_;  ///< prioritize predicates with marked
                                      ///< important variables
@@ -418,6 +420,7 @@ class PonoOptions
   static const unsigned int default_mbic3_indgen_mode = 0;
   static const bool default_ic3_functional_preimage_ = false;
   static const bool default_ic3_unsatcore_gen_ = true;
+  static const bool default_ic3bits_partial_model_pregen_ = false;
   static const bool default_ic3ia_reduce_preds_ = true;
   static const bool default_ic3ia_track_important_vars_ = true;
   static const bool default_ic3ia_sim_cex_ = true;

--- a/tests/test_partial_model.cpp
+++ b/tests/test_partial_model.cpp
@@ -30,6 +30,8 @@ class DynamicCoiUnitTests : public ::testing::Test,
 #define BVAND(x, y) (s->make_term(BVAnd, (x), (y)))
 #define BVOR(x, y) (s->make_term(BVOr, (x), (y)))
 #define EQ(x, y) (s->make_term(Equal, (x), (y)))
+#define BVULT(x, y) (s->make_term(BVUlt, (x), (y)))
+#define L_AND(x, y) (s->make_term(And, (x), (y)))
 // #define BoolEQ(x, y) (s->make_term(Iff, (x), (y)))
 #define ITE(c, x, y) (s->make_term(Ite, (c), (x), (y)))
 
@@ -107,6 +109,96 @@ TEST_P(DynamicCoiUnitTests, SimpleCoiTest)
   CheckPartialModel(e3, u);
   CheckPartialModel(e4a, u);
   CheckPartialModel(e4b, u);
+}
+
+#define CheckPartialModel_bitlevel(ast_in)              \
+  {                                                     \
+    s->push();                                          \
+    auto ast = (ast_in);                                \
+    s->assert_formula(ast);                             \
+    if (s->check_sat().is_sat()) {                      \
+      auto m_cube = pt.GetPartialModelInCube_bitlevel(ast);  \
+      s->pop();                                         \
+      s->push();                                        \
+      s->assert_formula(NOT(ast));                      \
+      s->assert_formula(m_cube.first.term);             \
+      EXPECT_TRUE(s->check_sat().is_unsat());           \
+    }                                                   \
+    s->pop();                                           \
+  }
+
+TEST_P(DynamicCoiUnitTests, BitCoiTest)
+{
+  Term a = s->make_symbol("a", bvsort8);
+  Term b = s->make_symbol("b", bvsort8);
+  Term c = s->make_symbol("c", bvsort8);
+  Term d = s->make_symbol("d", bvsort8);
+  Term e = s->make_symbol("e", bvsort8);
+  Term f = s->make_symbol("f", bvsort8);
+  Term g = s->make_symbol("g", bvsort8);
+
+  Term u = s->make_symbol("u", bvsort8);
+  Term v = s->make_symbol("v", bvsort8);
+  Term w = s->make_symbol("w", bvsort8);
+  Term x = s->make_symbol("x", bvsort8);
+  Term y = s->make_symbol("y", bvsort8);
+  Term z = s->make_symbol("z", bvsort8);
+
+  auto c0 = s->make_term(0, bvsort8);
+  auto c1 = s->make_term(1, bvsort8);
+  auto c2 = s->make_term(2, bvsort8);
+  auto c4 = s->make_term(4, bvsort8);
+  auto c8 = s->make_term(8, bvsort8);
+
+  auto x_plus_1 = ADD(x, c1);
+  auto x_sub_1 = SUB(x, c1);
+  auto x_and_1 = BVAND(x, c1);
+  auto x_plus_y = ADD(x, y);
+  auto x_sub_y = SUB(x, y);
+  auto x_and_y = BVAND(x, y);
+  auto t0 = BVAND(x, x_sub_1);
+  auto t1 = BVAND(y, x_sub_1);
+  auto t2 = ADD(x, x_sub_1);
+  auto t3 = ADD(x, SUB(x, c1));
+  auto t4 = ADD(x, x_and_1);
+  auto t5 = ADD(y, x_and_1);
+  auto t6 = ADD(y, BVAND(x, c1));
+  auto tc1 = L_AND(L_AND(L_AND(BVULT(x, c8), BVULT(c4, x)),
+                         L_AND(BVULT(y, c4), BVULT(c1, y))),
+                   EQ(BVAND(x, y), c0));
+  auto tc2 = L_AND(BVULT(c2, x), BVULT(c2, y));
+  auto tc3 = L_AND(L_AND(BVULT(c2, x), BVULT(c2, y)), BVULT(x, y));
+
+  auto e1 = ITE(EQ(SUB(x, y), z), ADD(a, b), c);
+  auto e2 = ITE(EQ(SUB(x, y), x), ADD(a, b), SUB(a, c));
+  auto e3 = ITE(EQ(BVAND(x, y), x), BVAND(a, b), BVOR(a, c));
+  auto e4a = ITE(EQ(SUB(u, SUB(v, w)), d), ADD(e, f), g);
+  auto e4b = ITE(
+      EQ(EQ(BVAND(a, SUB(e1, e2)), f), EQ(BVAND(x, y), x)), ADD(e4a, f), e1);
+
+  PartialModelGen pt(s);
+
+  CheckPartialModel_bitlevel(EQ(x_plus_1, u));
+  CheckPartialModel_bitlevel(EQ(x_sub_1, u));
+  CheckPartialModel_bitlevel(EQ(x_and_1, u));
+  CheckPartialModel_bitlevel(EQ(x_plus_y, u));
+  CheckPartialModel_bitlevel(EQ(x_sub_y, u));
+  CheckPartialModel_bitlevel(EQ(x_and_y, u));
+  CheckPartialModel_bitlevel(EQ(t0, u));
+  CheckPartialModel_bitlevel(EQ(t1, u));
+  CheckPartialModel_bitlevel(EQ(t2, u));
+  CheckPartialModel_bitlevel(EQ(t3, u));
+  CheckPartialModel_bitlevel(EQ(t4, u));
+  CheckPartialModel_bitlevel(EQ(t5, u));
+  CheckPartialModel_bitlevel(EQ(t6, u));
+  CheckPartialModel_bitlevel(EQ(e1, u));
+  CheckPartialModel_bitlevel(EQ(e2, u));
+  CheckPartialModel_bitlevel(EQ(e3, u));
+  CheckPartialModel_bitlevel(EQ(e4a, u));
+  CheckPartialModel_bitlevel(EQ(e4b, u));
+  CheckPartialModel_bitlevel(tc1);
+  CheckPartialModel_bitlevel(tc2);
+  CheckPartialModel_bitlevel(tc3);
 }
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedDynamicCoiUnitTests,

--- a/utils/partial_model.cpp
+++ b/utils/partial_model.cpp
@@ -17,11 +17,20 @@
 
 #include "utils/partial_model.h"
 
+#include <algorithm>
 #include <cassert>
+#include <list>
 
 #include "utils/str_util.h"
 
 namespace pono {
+
+static inline uint64_t unified_width(const smt::Term & ast)
+{
+  return ast->get_sort()->get_sort_kind() == smt::SortKind::BOOL
+             ? 1
+             : ast->get_sort()->get_width();
+}
 
 IC3Formula PartialModelGen::GetPartialModel(const smt::Term & ast)
 {
@@ -68,6 +77,112 @@ PartialModelGen::GetPartialModelInCube(const smt::Term & ast)
       syntax_analysis::IC3FormulaModel(std::move(cube), conj));
 }
 
+IC3Formula PartialModelGen::GetPartialModel_bitlevel(const smt::Term & ast)
+{
+  auto high = static_cast<int>(unified_width(ast)) - 1;
+  std::unordered_map<smt::Term, std::vector<std::pair<int, int>>>
+      output_var_slices;
+
+  GetVarListForAsts_in_bitlevel(
+      { { ast, std::vector<std::pair<int, int>>(1, { high, 0 }) } },
+      output_var_slices);
+
+  smt::Term conj;
+  smt::TermVec conjvec;
+  for (const auto & var_vec_pair : output_var_slices) {
+    const auto & v = var_vec_pair.first;
+    const auto & slices = var_vec_pair.second;
+    smt::Term val = solver_->get_value(v);
+    if (v->get_sort()->get_sort_kind() == smt::SortKind::BOOL) {
+      auto eq = solver_->make_term(smt::Op(smt::PrimOp::Equal), v, val);
+      conjvec.push_back(eq);
+      if (conj) {
+        conj = solver_->make_term(smt::Op(smt::PrimOp::And), conj, eq);
+      } else {
+        conj = eq;
+      }
+      continue;
+    }
+
+    for (const auto & bitfield : slices) {
+      auto left = solver_->make_term(
+          smt::Op(smt::PrimOp::Extract, bitfield.first, bitfield.second), v);
+      auto right = solver_->make_term(
+          smt::Op(smt::PrimOp::Extract, bitfield.first, bitfield.second), val);
+      auto eq = solver_->make_term(smt::Op(smt::PrimOp::Equal), left, right);
+
+      conjvec.push_back(eq);
+      if (conj) {
+        conj = solver_->make_term(smt::Op(smt::PrimOp::And), conj, eq);
+      } else {
+        conj = eq;
+      }
+    }
+  }
+  if (!conj) {  // generally, this should not happen
+    conj = solver_->make_term(true);
+    conjvec.push_back(conj);
+  }
+  return IC3Formula(conj, conjvec, false /*not a disjunction*/);
+}
+
+std::pair<IC3Formula, syntax_analysis::IC3FormulaModel>
+PartialModelGen::GetPartialModelInCube_bitlevel(const smt::Term & ast)
+{
+  auto high = static_cast<int>(unified_width(ast)) - 1;
+  std::unordered_map<smt::Term, std::vector<std::pair<int, int>>>
+      output_var_slices;
+
+  GetVarListForAsts_in_bitlevel(
+      { { ast, std::vector<std::pair<int, int>>(1, { high, 0 }) } },
+      output_var_slices);
+
+  std::unordered_map<smt::Term, smt::Term> cube;
+
+  smt::Term conj;
+  smt::TermVec conjvec;
+  for (const auto & var_vec_pair : output_var_slices) {
+    const auto & v = var_vec_pair.first;
+    const auto & slices = var_vec_pair.second;
+    smt::Term val = solver_->get_value(v);
+    if (v->get_sort()->get_sort_kind() == smt::SortKind::BOOL) {
+      auto eq = solver_->make_term(smt::Op(smt::PrimOp::Equal), v, val);
+      cube.emplace(v, val);
+      conjvec.push_back(eq);
+      if (conj) {
+        conj = solver_->make_term(smt::Op(smt::PrimOp::And), conj, eq);
+      } else {
+        conj = eq;
+      }
+      continue;
+    }
+
+    for (const auto & bitfield : slices) {
+      auto left = solver_->make_term(
+          smt::Op(smt::PrimOp::Extract, bitfield.first, bitfield.second), v);
+      auto right = solver_->make_term(
+          smt::Op(smt::PrimOp::Extract, bitfield.first, bitfield.second), val);
+      auto eq = solver_->make_term(smt::Op(smt::PrimOp::Equal), left, right);
+
+      cube.emplace(left, right);
+      conjvec.push_back(eq);
+      if (conj) {
+        conj = solver_->make_term(smt::Op(smt::PrimOp::And), conj, eq);
+      } else {
+        conj = eq;
+      }
+    }
+  }
+  if (!conj) {
+    conj = solver_->make_term(true);
+    conjvec.push_back(conj);
+  }
+
+  return std::make_pair(
+      IC3Formula(conj, conjvec, false /*not a disjunction*/),
+      syntax_analysis::IC3FormulaModel(std::move(cube), conj));
+}
+
 void PartialModelGen::GetVarList(const smt::Term & ast)
 {
   dfs_walked_.clear();
@@ -82,6 +197,71 @@ void PartialModelGen::GetVarList(const smt::Term & ast,
   dfs_vars_.clear();
   dfs_walk(ast);
   out_vars.insert(dfs_vars_.begin(), dfs_vars_.end());
+}
+
+static inline bool in_range(int i, int left, int right)
+{
+  return i <= left + 1 && i >= right - 1;
+}
+
+static inline bool mergeable(const std::pair<int, int> & a,
+                             const std::pair<int, int> & b)
+{
+  return in_range(a.first, b.first, b.second)
+         || in_range(a.second, b.first, b.second)
+         || in_range(b.first, a.first, a.second)
+         || in_range(b.second, a.first, a.second);
+}
+
+static inline std::pair<int, int> merge_range(
+    const std::pair<int, int> & l, const std::pair<int, int> & r)
+{
+  return { std::max(l.first, r.first), std::min(l.second, r.second) };
+}
+
+static std::vector<std::pair<int, int>> merge_intervals(
+    const std::vector<std::pair<int, int>> & intervals)
+{
+  if (intervals.size() <= 1) return intervals;
+
+  std::list<std::pair<int, int>> merged;
+  for (auto r : intervals) {
+    auto pos = merged.begin();
+    while (pos != merged.end()) {
+      if (mergeable(*pos, r)) {
+        r = merge_range(*pos, r);
+        merged.erase(pos);
+        pos = merged.begin();
+      } else {
+        ++pos;
+      }
+    }
+    merged.push_back(r);
+  }
+
+  return std::vector<std::pair<int, int>>(merged.begin(), merged.end());
+}
+
+void PartialModelGen::GetVarListForAsts_in_bitlevel(
+    const std::unordered_map<smt::Term, std::vector<std::pair<int, int>>> &
+        input_asts_slices,
+    std::unordered_map<smt::Term, std::vector<std::pair<int, int>>> & out)
+{
+  // Multiple paths can require overlapping or adjacent slices of the same
+  // variable. Merge them so callers can build compact equality constraints.
+  dfs_walked_extract_.clear();
+  std::unordered_map<smt::Term, PairSet> varset_slices;
+  for (const auto & ast_slice_pair : input_asts_slices) {
+    for (const auto & h_l_pair : ast_slice_pair.second) {
+      dfs_walk_bitlevel(
+          ast_slice_pair.first, h_l_pair.first, h_l_pair.second, varset_slices);
+    }
+  }
+  for (const auto & var_slice_pair : varset_slices) {
+    std::vector<std::pair<int, int>> intervals(var_slice_pair.second.begin(),
+                                               var_slice_pair.second.end());
+    out.emplace(var_slice_pair.first, merge_intervals(intervals));
+  }
 }
 
 void PartialModelGen::GetVarListForAsts(const smt::TermVec & asts,
@@ -187,7 +367,128 @@ static inline bool is_all_one(const std::string & s, uint64_t w)
   return convert_to_boolean_and_check(decimal, width, true);
 }
 
+static std::string decimal_to_binary(std::string decimal)
+{
+  // Avoid fixed-width integer conversion here; SMT models may print decimal
+  // bit-vector constants wider than native integer types.
+  decimal.erase(0, decimal.find_first_not_of('0'));
+  if (decimal.empty()) return "0";
+
+  std::string binary;
+  while (!decimal.empty()) {
+    std::string quotient;
+    int carry = 0;
+    for (char c : decimal) {
+      int value = carry * 10 + (c - '0');
+      int digit = value / 2;
+      carry = value % 2;
+      if (!quotient.empty() || digit != 0) {
+        quotient.push_back(static_cast<char>('0' + digit));
+      }
+    }
+    binary.push_back(static_cast<char>('0' + carry));
+    decimal = quotient;
+  }
+
+  std::reverse(binary.begin(), binary.end());
+  return binary;
+}
+
+// #b0000 -> 0000
+// (_ bvX W) -> X in binary (W-wide)
+static inline std::string to_unified_bvconst(const std::string & s)
+{
+  // Normalize solver-specific BV value strings so bit index 0 is the last
+  // character before find_consecutive_zeros_ones reverses the string.
+  if (s.substr(0, 2) == "#b") return s.substr(2);
+
+  std::string decimal, width;
+  bool conv_succ = extract_decimal_width(s, decimal, width);
+  assert(conv_succ);
+
+  auto binary = decimal_to_binary(decimal);
+  auto width_int = syntax_analysis::StrToULongLong(width, 10);
+  if (binary.length() < width_int) {
+    binary.insert(0, width_int - binary.size(), '0');
+  }
+  return binary;
+}
+
+static void find_consecutive_zeros_ones(
+    std::string s,
+    const std::vector<std::pair<int, int>> & ranges,
+    std::vector<std::pair<int, int>> & ranges_of_zeros,
+    std::vector<std::pair<int, int>> & ranges_of_ones)
+{
+  std::reverse(s.begin(), s.end());
+  for (const auto & msb_lsb_pair : ranges) {
+    auto msb = msb_lsb_pair.first;
+    auto lsb = msb_lsb_pair.second;
+    assert(lsb >= 0 && msb < static_cast<int>(s.length()) && msb >= lsb);
+
+    int prev_i = lsb;
+    for (int i = lsb + 1; i <= msb + 1; ++i) {
+      if (i == msb + 1 || s[i] != s[prev_i]) {
+        if (s[prev_i] == '0') {
+          ranges_of_zeros.push_back({ i - 1, prev_i });
+        } else {
+          ranges_of_ones.push_back({ i - 1, prev_i });
+        }
+        prev_i = i;
+      }
+    }
+  }
+}
+
+static inline std::string bool2bv_str(const std::string & in)
+{
+  if (in == "true") return "#b1";
+  if (in == "false") return "#b0";
+  return in;
+}
+
+static int find_rightmost_index_with_different_bit(const std::string & left,
+                                                   const std::string & right,
+                                                   size_t width)
+{
+  auto l = to_unified_bvconst(bool2bv_str(left));
+  auto r = to_unified_bvconst(bool2bv_str(right));
+  assert(!l.empty() && !r.empty());
+  assert(l.length() == r.length() && l.length() == width);
+
+  int bitindex = 0;
+  for (int pos = static_cast<int>(l.length()) - 1; pos >= 0; --pos) {
+    if (l.at(pos) != r.at(pos)) return bitindex;
+    ++bitindex;
+  }
+  assert(static_cast<size_t>(bitindex) <= width);
+  return -1;
+}
+
+static int find_leftmost_index_with_different_bit(const std::string & left,
+                                                  const std::string & right,
+                                                  size_t width)
+{
+  auto l = to_unified_bvconst(bool2bv_str(left));
+  auto r = to_unified_bvconst(bool2bv_str(right));
+  assert(!l.empty() && !r.empty());
+  assert(l.length() == r.length() && l.length() == width);
+
+  int bitindex = static_cast<int>(width) - 1;
+  for (size_t pos = 0; pos < width; ++pos) {
+    if (l.at(pos) != r.at(pos)) return bitindex;
+    --bitindex;
+  }
+  assert(bitindex >= -1);
+  return 0;
+}
+
 /* Internal Macros */
+#define ARG1(a1)             \
+  auto ptr = ast->begin();   \
+  auto a1 = *(ptr++);        \
+  assert(ptr == ast->end());
+
 #define ARG2(a1, a2)       \
   auto ptr = ast->begin(); \
   auto a1 = *(ptr++);      \
@@ -328,5 +629,279 @@ void PartialModelGen::dfs_walk(const smt::Term & input_ast)
     }  // end non-variable case
   }  // while ( not empty )
 }  // end of PartialModelGen::dfs_walk
+
+void PartialModelGen::dfs_walk_bitlevel(
+    const smt::Term & input_ast,
+    int high,
+    int low,
+    std::unordered_map<smt::Term, PairSet> & varset_slice)
+{
+  std::vector<std::pair<smt::Term, std::pair<int, int>>> node_stack_;
+
+  // The stack stores a term plus the output slice whose value must be
+  // justified by the partial model.
+  auto input_width = static_cast<int>(unified_width(input_ast));
+  assert(high >= low && low >= 0 && high < input_width);
+  node_stack_.push_back({ input_ast, { high, low } });
+
+  while (!node_stack_.empty()) {
+    auto ast = node_stack_.back().first;
+    auto extracted_bit = node_stack_.back().second;
+    auto width = static_cast<int>(unified_width(ast));
+    assert(extracted_bit.second >= 0
+           && extracted_bit.first >= extracted_bit.second
+           && extracted_bit.first < width);
+
+    auto pos = dfs_walked_extract_.find(ast);
+    if (pos != dfs_walked_extract_.end()
+        && pos->second.find(extracted_bit) != pos->second.end()) {
+      node_stack_.pop_back();
+      continue;
+    }
+    dfs_walked_extract_[ast].insert(extracted_bit);
+
+    smt::Op op = ast->get_op();
+    if (op.is_null()) {
+      if (ast->is_symbolic_const()) {
+        varset_slice[ast].insert(extracted_bit);
+      }
+      node_stack_.pop_back();
+      continue;
+    } else {
+      if (op.prim_op == smt::PrimOp::Ite) {
+        ARG3(cond, texpr, fexpr)
+        auto cond_val = solver_->get_value(cond);
+        assert(cond_val->is_value());
+        if (is_all_one(cond_val->to_string(), 1)) {
+          node_stack_.push_back({ cond, { 0, 0 } });
+          node_stack_.push_back({ texpr, extracted_bit });
+        } else {
+          node_stack_.push_back({ cond, { 0, 0 } });
+          node_stack_.push_back({ fexpr, extracted_bit });
+        }
+      } else if (op.prim_op == smt::PrimOp::Implies) {
+        ARG2(left, right)
+        auto cond_left = solver_->get_value(left);
+        auto cond_right = solver_->get_value(right);
+        assert(cond_left->is_value() && cond_right->is_value());
+        assert(unified_width(ast) == 1);
+        if (!is_all_one(cond_left->to_string(), 1)) {
+          node_stack_.push_back({ left, { 0, 0 } });
+        } else if (is_all_one(cond_right->to_string(), 1)) {
+          node_stack_.push_back({ right, { 0, 0 } });
+        } else {
+          node_stack_.push_back({ left, { 0, 0 } });
+          node_stack_.push_back({ right, { 0, 0 } });
+        }
+      } else if (op.prim_op == smt::PrimOp::And) {
+        ARG2(left, right)
+        auto cond_left = solver_->get_value(left);
+        auto cond_right = solver_->get_value(right);
+        assert(cond_left->is_value() && cond_right->is_value());
+        assert(unified_width(ast) == 1);
+        if (!is_all_one(cond_left->to_string(), 1)) {
+          node_stack_.push_back({ left, { 0, 0 } });
+        } else if (!is_all_one(cond_right->to_string(), 1)) {
+          node_stack_.push_back({ right, { 0, 0 } });
+        } else {
+          node_stack_.push_back({ left, { 0, 0 } });
+          node_stack_.push_back({ right, { 0, 0 } });
+        }
+      } else if (op.prim_op == smt::PrimOp::Or) {
+        ARG2(left, right)
+        auto cond_left = solver_->get_value(left);
+        auto cond_right = solver_->get_value(right);
+        assert(cond_left->is_value() && cond_right->is_value());
+        assert(unified_width(ast) == 1);
+        if (is_all_one(cond_left->to_string(), 1)) {
+          node_stack_.push_back({ left, { 0, 0 } });
+        } else if (is_all_one(cond_right->to_string(), 1)) {
+          node_stack_.push_back({ right, { 0, 0 } });
+        } else {
+          node_stack_.push_back({ left, { 0, 0 } });
+          node_stack_.push_back({ right, { 0, 0 } });
+        }
+      } else if (op.prim_op == smt::PrimOp::BVAnd
+                 || op.prim_op == smt::PrimOp::BVNand) {
+        ARG2(left, right)
+        auto cond_left = solver_->get_value(left);
+        auto cond_right = solver_->get_value(right);
+        assert(cond_left->is_value() && cond_right->is_value());
+        std::string left_val = to_unified_bvconst(cond_left->to_string());
+        std::string right_val = to_unified_bvconst(cond_right->to_string());
+
+        // For AND, a zero bit on either side is enough; only one/one bits
+        // require both operands to be tracked.
+        std::vector<std::pair<int, int>> left_zero, left_one;
+        find_consecutive_zeros_ones(
+            left_val, { extracted_bit }, left_zero, left_one);
+        for (const auto & z : left_zero) node_stack_.push_back({ left, z });
+
+        std::vector<std::pair<int, int>> right_zero, right_one;
+        find_consecutive_zeros_ones(
+            right_val, left_one, right_zero, right_one);
+        for (const auto & z : right_zero) node_stack_.push_back({ right, z });
+        for (const auto & both_one : right_one) {
+          node_stack_.push_back({ left, both_one });
+          node_stack_.push_back({ right, both_one });
+        }
+      } else if (op.prim_op == smt::PrimOp::BVOr
+                 || op.prim_op == smt::PrimOp::BVNor) {
+        ARG2(left, right)
+        auto cond_left = solver_->get_value(left);
+        auto cond_right = solver_->get_value(right);
+        assert(cond_left->is_value() && cond_right->is_value());
+        std::string left_val = to_unified_bvconst(cond_left->to_string());
+        std::string right_val = to_unified_bvconst(cond_right->to_string());
+
+        // Dual of AND: a one bit on either side is enough; zero/zero bits
+        // require both operands to be tracked.
+        std::vector<std::pair<int, int>> left_zero, left_one;
+        find_consecutive_zeros_ones(
+            left_val, { extracted_bit }, left_zero, left_one);
+        for (const auto & one : left_one) {
+          node_stack_.push_back({ left, one });
+        }
+
+        std::vector<std::pair<int, int>> right_zero, right_one;
+        find_consecutive_zeros_ones(
+            right_val, left_zero, right_zero, right_one);
+        for (const auto & one : right_one) {
+          node_stack_.push_back({ right, one });
+        }
+        for (const auto & both_zero : right_zero) {
+          node_stack_.push_back({ left, both_zero });
+          node_stack_.push_back({ right, both_zero });
+        }
+      } else if (op.prim_op == smt::PrimOp::BVMul) {
+        ARG2(left, right)
+        auto cond_left = solver_->get_value(left);
+        auto cond_right = solver_->get_value(right);
+        assert(cond_left->is_value() && cond_right->is_value());
+        std::string left_val = cond_left->to_string();
+        std::string right_val = cond_right->to_string();
+        auto left_w = static_cast<int>(unified_width(left));
+        auto right_w = static_cast<int>(unified_width(right));
+        if (is_all_zero(left_val)) {
+          node_stack_.push_back({ left, { left_w - 1, 0 } });
+        } else if (is_all_zero(right_val)) {
+          node_stack_.push_back({ right, { right_w - 1, 0 } });
+        } else {
+          node_stack_.push_back({ left, { left_w - 1, 0 } });
+          node_stack_.push_back({ right, { right_w - 1, 0 } });
+        }
+      } else if (op.prim_op == smt::PrimOp::BVAdd) {
+        ARG2(left, right)
+        auto msb = extracted_bit.first;
+        // Carries from lower bits can affect any requested output bit.
+        node_stack_.push_back({ left, { msb, 0 } });
+        node_stack_.push_back({ right, { msb, 0 } });
+      } else if (op.prim_op == smt::PrimOp::BVNot) {
+        ARG1(back)
+        node_stack_.push_back({ back, extracted_bit });
+      } else if (op.prim_op == smt::PrimOp::BVXor
+                 || op.prim_op == smt::PrimOp::BVXnor) {
+        ARG2(left, right)
+        node_stack_.push_back({ left, extracted_bit });
+        node_stack_.push_back({ right, extracted_bit });
+      } else if (op.prim_op == smt::PrimOp::Extract) {
+        auto lsb_shift = op.idx1;
+        auto msb = extracted_bit.first;
+        auto lsb = extracted_bit.second;
+        for (const auto & arg : *ast) {
+          node_stack_.push_back(
+              { arg, { static_cast<int>(lsb_shift + msb),
+                       static_cast<int>(lsb_shift + lsb) } });
+        }
+      } else if (op.prim_op == smt::PrimOp::Concat) {
+        ARG2(left, right)
+        auto width_right = static_cast<int>(unified_width(right));
+        auto msb = extracted_bit.first;
+        auto lsb = extracted_bit.second;
+        if (lsb >= width_right) {
+          node_stack_.push_back(
+              { left, { msb - width_right, lsb - width_right } });
+        } else if (msb < width_right) {
+          node_stack_.push_back({ right, { msb, lsb } });
+        } else {
+          node_stack_.push_back({ left, { msb - width_right, 0 } });
+          node_stack_.push_back({ right, { width_right - 1, lsb } });
+        }
+      } else if (op.prim_op == smt::PrimOp::Zero_Extend
+                 || op.prim_op == smt::PrimOp::Sign_Extend) {
+        ARG1(back)
+        auto width_back = static_cast<int>(unified_width(back));
+        auto msb = extracted_bit.first;
+        auto lsb = extracted_bit.second;
+        if (lsb < width_back) {
+          if (msb >= width_back) {
+            node_stack_.push_back({ back, { width_back - 1, lsb } });
+          } else {
+            node_stack_.push_back({ back, { msb, lsb } });
+          }
+        }
+      } else if (op.prim_op == smt::PrimOp::Equal
+                 || op.prim_op == smt::PrimOp::Distinct
+                 || op.prim_op == smt::PrimOp::BVComp) {
+        ARG2(left, right)
+        auto result_val = solver_->get_value(ast)->to_string();
+        if (((op.prim_op == smt::PrimOp::Equal
+              || op.prim_op == smt::PrimOp::BVComp)
+             && is_all_one(result_val, 1))
+            || (op.prim_op == smt::PrimOp::Distinct
+                && is_all_zero(result_val))) {
+          auto left_width = static_cast<int>(unified_width(left));
+          auto right_width = static_cast<int>(unified_width(right));
+          node_stack_.push_back({ left, { left_width - 1, 0 } });
+          node_stack_.push_back({ right, { right_width - 1, 0 } });
+        } else {
+          // For a disequality/equality that evaluates false, one differing bit
+          // is enough to justify the Boolean result.
+          auto left_value = solver_->get_value(left)->to_string();
+          auto right_value = solver_->get_value(right)->to_string();
+          auto left_width = unified_width(left);
+          auto right_width = unified_width(right);
+          assert(left_width == right_width);
+          assert(left_value != right_value);
+
+          int rightmost_difference = find_rightmost_index_with_different_bit(
+              left_value, right_value, left_width);
+          assert(rightmost_difference != -1);
+
+          node_stack_.push_back(
+              { left, { rightmost_difference, rightmost_difference } });
+          node_stack_.push_back(
+              { right, { rightmost_difference, rightmost_difference } });
+        }
+      } else if (op.prim_op == smt::PrimOp::BVUlt
+                 || op.prim_op == smt::PrimOp::BVUle
+                 || op.prim_op == smt::PrimOp::BVUgt
+                 || op.prim_op == smt::PrimOp::BVUge) {
+        ARG2(left, right)
+        auto left_value = solver_->get_value(left)->to_string();
+        auto right_value = solver_->get_value(right)->to_string();
+        auto left_width = unified_width(left);
+        auto right_width = unified_width(right);
+        assert(left_width == right_width);
+
+        // Unsigned comparisons are decided by the most significant differing
+        // bit; equal operands fall back to bit 0.
+        int leftmost_difference = find_leftmost_index_with_different_bit(
+            left_value, right_value, left_width);
+        node_stack_.push_back(
+            { left,
+              { static_cast<int>(left_width) - 1, leftmost_difference } });
+        node_stack_.push_back(
+            { right,
+              { static_cast<int>(right_width) - 1, leftmost_difference } });
+      } else {
+        for (const auto & arg : *ast) {
+          auto arg_width = static_cast<int>(unified_width(arg));
+          node_stack_.push_back({ arg, { arg_width - 1, 0 } });
+        }
+      }
+    }
+  }
+}
 
 }  // namespace pono

--- a/utils/partial_model.h
+++ b/utils/partial_model.h
@@ -17,6 +17,11 @@
 
 #pragma once
 
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
 #include "engines/ic3base.h"
 #include "utils/sygus_ic3formula_helper.h"
 
@@ -24,6 +29,21 @@ namespace pono {
 
 class PartialModelGen
 {
+ private:
+  // Bit slices are represented as inclusive [msb, lsb] pairs.
+  struct HashPair
+  {
+    template <class T1, class T2>
+    size_t operator()(const std::pair<T1, T2> & p) const
+    {
+      auto hash1 = std::hash<T1>{}(p.first);
+      auto hash2 = std::hash<T2>{}(p.second);
+      return hash1 == hash2 ? hash1 : hash1 ^ hash2;
+    }
+  };
+
+  typedef std::unordered_set<std::pair<int, int>, HashPair> PairSet;
+
  public:
   /** This class computes the cone of influence on construction
    *  The current implementation does not have internal cache,
@@ -43,7 +63,17 @@ class PartialModelGen
   // for the DFS, will not use the stack but use one reference here
   std::unordered_set<smt::Term> dfs_walked_;
   std::unordered_set<smt::Term> dfs_vars_;
+  std::unordered_map<smt::Term, PairSet> dfs_walked_extract_;
+
   void dfs_walk(const smt::Term & ast);
+
+  // Model-guided DFS that records which bit slices of each symbolic constant
+  // are sufficient to justify the selected slice of ast.
+  void dfs_walk_bitlevel(
+      const smt::Term & ast,
+      int high,
+      int low,
+      std::unordered_map<smt::Term, PairSet> & varset_slice);
 
   // condition var buffer
   void GetVarList(const smt::Term & ast);
@@ -56,6 +86,12 @@ class PartialModelGen
    */
   void GetVarList(const smt::Term & ast,
                   std::unordered_set<smt::Term> & out_vars);
+
+  void GetVarListForAsts_in_bitlevel(
+      const std::unordered_map<smt::Term, std::vector<std::pair<int, int>>> &
+          input_asts_slices,
+      std::unordered_map<smt::Term, std::vector<std::pair<int, int>>> &
+          varset_slice);
 
   /** This class computes the variables that need to
    *  appear in the partial model of asts in the vector
@@ -79,6 +115,21 @@ class PartialModelGen
    */
   std::pair<IC3Formula, syntax_analysis::IC3FormulaModel> GetPartialModelInCube(
       const smt::Term & ast);
+
+  /** This class computes the variables that need to
+   *  appear in the partial model of asts in the vector
+   *  @param the ast to walk
+   *  @return the partial model in ic3formula
+   */
+  IC3Formula GetPartialModel_bitlevel(const smt::Term & ast);
+
+  /** This class computes the variables that need to
+   *  appear in the partial model of asts in the vector
+   *  @param the ast to walk
+   *  @return the partial model and the var/val cube
+   */
+  std::pair<IC3Formula, syntax_analysis::IC3FormulaModel>
+  GetPartialModelInCube_bitlevel(const smt::Term & ast);
 
   // add an API to use buffers
 };


### PR DESCRIPTION

## Summary

This PR adds a bit-level partial-model predecessor generalization path for `IC3Bits`, controlled by a new opt-in flag:

```text
--ic3bits-partial-model-pregen
```
By default, `IC3Bits` keeps using the existing parent `IC3` predecessor generalization. When the new flag is enabled, `IC3Bits` extracts a bit-level partial model for the predecessor cube instead.


## Changes

- Add bit-level partial-model extraction support to `PartialModelGen`.
  - Tracks relevant inclusive bit slices `[msb, lsb]` through supported BV and
    Boolean operators.
  - Builds compact equality cubes over only the model-relevant variable slices.
- Integrate the partial-model extractor into `IC3Bits`.
- Add the `--ic3bits-partial-model-pregen` option.
  - Default is disabled.

## Performance

The option `--ic3bits-partial-model-pregen` solves 25 more instances. 

<img width="1280" height="800" alt="cactus-original-vs-partialmodel" src="https://github.com/user-attachments/assets/c44d2742-a330-4ea3-a2b7-2d4decbc443f" />

Below is a per-instance comparison.

<img width="1280" height="1280" alt="scatter-solved-original-vs-partialmodel" src="https://github.com/user-attachments/assets/64b5cfd7-0e96-4144-8a00-e4bb41187d0a" />

## Note

I think these commits will make the structure of ic3bits a bit messy, so it is also okay not to merge these commits. I just want to take this opportunity to record our code change and the observed performance.  If there is any revision wanted, please feel free to let me know. Thanks!


