### PR TITLE
Integrate smt-switch via find_package(SmtSwitch)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,79 +81,29 @@ if(NOT FLEX_INCLUDE_DIRS)
   message(FATAL_ERROR "Missing flex headers")
 endif()
 
-if(NOT DEFINED SMT_SWITCH_DIR)
-  set(SMT_SWITCH_DIR "${PROJECT_SOURCE_DIR}/deps/smt-switch")
-endif()
-
-# TODO: Use find_package
-# find package
-#list(APPEND CMAKE_PREFIX_PATH "${PROJECT_SOURCE_DIR}/smt-switch")
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 find_package(PkgConfig REQUIRED)
 
-# Check that dependencies are there
-list(APPEND CMAKE_PREFIX_PATH "${SMT_SWITCH_DIR}/deps/install")
-
 pkg_check_modules(GMPXX REQUIRED gmpxx)
-pkg_check_modules(BITWUZLA REQUIRED bitwuzla)
 
-if(NOT EXISTS "${SMT_SWITCH_DIR}/local/include/smt-switch/smt.h")
-  message(FATAL_ERROR "Missing smt-switch headers -- try running ./contrib/setup-smt-switch.sh")
-endif()
-
-if(NOT EXISTS "${SMT_SWITCH_DIR}/local/lib/libsmt-switch.a")
-  message(FATAL_ERROR "Missing smt-switch library -- try running ./contrib/setup-smt-switch.sh")
-endif()
-
-if(NOT EXISTS "${SMT_SWITCH_DIR}/local/lib/libsmt-switch-bitwuzla.a")
-  message(
-    FATAL_ERROR
-    "Missing smt-switch Bitwuzla library -- try running ./contrib/setup-smt-switch.sh"
-  )
-endif()
-
-if(NOT EXISTS "${SMT_SWITCH_DIR}/local/lib/libsmt-switch-cvc5.a")
-  message(
-    FATAL_ERROR
-    "Missing smt-switch cvc5 library -- try running ./contrib/setup-smt-switch.sh"
-  )
-endif()
-
+set(SmtSwitch_FIND_COMPONENTS bitwuzla cvc5)
 if(WITH_BOOLECTOR)
-  if(NOT EXISTS "${SMT_SWITCH_DIR}/local/lib/libsmt-switch-btor.a")
-    message(
-      FATAL_ERROR
-      "Missing smt-switch Boolector library -- try running ./contrib/setup-smt-switch.sh --with-btor"
-    )
-  endif()
+  list(APPEND SmtSwitch_FIND_COMPONENTS btor)
 endif()
-
 if(WITH_MSAT)
-  if(NOT EXISTS "${SMT_SWITCH_DIR}/local/lib/libsmt-switch-msat.a")
-    message(
-      FATAL_ERROR
-      "Missing smt-switch mathsat library -- try running ./contrib/setup-smt-switch.sh --with-msat"
-    )
-  endif()
+  list(APPEND SmtSwitch_FIND_COMPONENTS msat)
 endif()
-
 if(WITH_YICES2)
-  if(NOT EXISTS "${SMT_SWITCH_DIR}/local/lib/libsmt-switch-yices2.a")
-    message(
-      FATAL_ERROR
-      "Missing smt-switch Yices2 library -- try running ./contrib/setup-smt-switch.sh --with-yices2"
-    )
-  endif()
+  list(APPEND SmtSwitch_FIND_COMPONENTS yices2)
 endif()
+if(WITH_Z3)
+  list(APPEND SmtSwitch_FIND_COMPONENTS z3)
+endif()
+find_package(SmtSwitch REQUIRED COMPONENTS ${SmtSwitch_FIND_COMPONENTS})
 
 if(WITH_Z3)
   find_package(Z3 REQUIRED)
-  if(NOT EXISTS "${SMT_SWITCH_DIR}/local/lib/libsmt-switch-z3.a")
-    message(
-      FATAL_ERROR
-      "Missing smt-switch Z3 library -- try running ./contrib/setup-smt-switch.sh --with-z3"
-    )
-  endif()
 endif()
 
 if(WITH_MSAT_IC3IA)
@@ -212,7 +162,6 @@ set(
   "${PROJECT_SOURCE_DIR}/contrib/"
   "${PROJECT_SOURCE_DIR}/contrib/optionparser-1.7/src"
   ${Btor2Tools_INCLUDE_DIRS}
-  "${SMT_SWITCH_DIR}/local/include"
   # generated Bison headers go in build directory
   "${CMAKE_CURRENT_BINARY_DIR}"
   ${GMPXX_INCLUDE_DIRS}
@@ -315,23 +264,23 @@ if(BUILD_PYTHON_BINDINGS)
   add_subdirectory(python)
 endif()
 
-target_link_libraries(pono-lib PUBLIC "${SMT_SWITCH_DIR}/local/lib/libsmt-switch-bitwuzla.a")
-target_link_libraries(pono-lib PUBLIC "${SMT_SWITCH_DIR}/local/lib/libsmt-switch-cvc5.a")
+target_link_libraries(pono-lib PUBLIC smt-switch-bitwuzla)
+target_link_libraries(pono-lib PUBLIC smt-switch-cvc5)
 
 if(WITH_BOOLECTOR)
-  target_link_libraries(pono-lib PUBLIC "${SMT_SWITCH_DIR}/local/lib/libsmt-switch-btor.a")
+  target_link_libraries(pono-lib PUBLIC smt-switch-btor)
 endif()
 
 if(WITH_MSAT)
-  target_link_libraries(pono-lib PUBLIC "${SMT_SWITCH_DIR}/local/lib/libsmt-switch-msat.a")
+  target_link_libraries(pono-lib PUBLIC smt-switch-msat)
 endif()
 
 if(WITH_YICES2)
-  target_link_libraries(pono-lib PUBLIC "${SMT_SWITCH_DIR}/local/lib/libsmt-switch-yices2.a")
+  target_link_libraries(pono-lib PUBLIC smt-switch-yices2)
 endif()
 
 if(WITH_Z3)
-  target_link_libraries(pono-lib PRIVATE "${SMT_SWITCH_DIR}/local/lib/libsmt-switch-z3.a")
+  target_link_libraries(pono-lib PRIVATE smt-switch-z3)
   target_link_libraries(pono-lib PRIVATE z3::libz3)
 endif()
 
@@ -374,9 +323,8 @@ if(WITH_COREIR)
   )
 endif()
 
-target_link_libraries(pono-lib PUBLIC "${SMT_SWITCH_DIR}/local/lib/libsmt-switch.a")
+target_link_libraries(pono-lib PUBLIC smt-switch)
 target_link_libraries(pono-lib PUBLIC ${Btor2Tools_LIBRARIES})
-target_link_libraries(pono-lib PUBLIC "${BITWUZLA_LDFLAGS}")
 target_link_libraries(pono-lib PUBLIC "${GMPXX_LDFLAGS}")
 target_link_libraries(pono-lib PUBLIC pthread)
 
@@ -400,7 +348,6 @@ target_include_directories(
     "${PROJECT_SOURCE_DIR}/core"
     "${PROJECT_SOURCE_DIR}/contrib/"
     "${PROJECT_SOURCE_DIR}/contrib/optionparser-1.7/src"
-    "${SMT_SWITCH_DIR}/local/include"
 )
 
 target_link_libraries(pono-bin PUBLIC pono-lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,10 +102,6 @@ if(WITH_Z3)
 endif()
 find_package(SmtSwitch REQUIRED COMPONENTS ${SmtSwitch_FIND_COMPONENTS})
 
-if(WITH_Z3)
-  find_package(Z3 REQUIRED)
-endif()
-
 if(WITH_MSAT_IC3IA)
   if(NOT EXISTS "${PROJECT_SOURCE_DIR}/deps/ic3ia/build/libic3ia.a")
     message(FATAL_ERROR "Missing ic3ia library -- try running ./contrib/setup-ic3ia.sh")
@@ -281,7 +277,6 @@ endif()
 
 if(WITH_Z3)
   target_link_libraries(pono-lib PRIVATE smt-switch-z3)
-  target_link_libraries(pono-lib PRIVATE z3::libz3)
 endif()
 
 if(WITH_MSAT_IC3IA)

--- a/cmake/FindSmtSwitch.cmake
+++ b/cmake/FindSmtSwitch.cmake
@@ -25,6 +25,12 @@ Hints
   smt-switch's own ``contrib/setup-bitwuzla.sh``) are expected under
   ``${SMT_SWITCH_DIR}/deps/install``.
 
+Requesting the ``z3`` component additionally requires a Z3 installation
+discoverable via its own CMake package config, since smt-switch's own Z3
+backend links against it directly. smt-switch's own ``contrib/setup-z3.sh``
+installs Z3 into ``${SMT_SWITCH_DIR}/deps/install``; that location is always
+preferred over a system-wide Z3 installation if both are present.
+
 Components
 ^^^^^^^^^^
 
@@ -113,14 +119,23 @@ if(SmtSwitch_FOUND AND NOT TARGET smt-switch)
     )
   endif()
 
-  foreach(
-    _comp
-    cvc5
-    btor
-    msat
-    yices2
-    z3
-  )
+  if("z3" IN_LIST SmtSwitch_FIND_COMPONENTS AND NOT TARGET smt-switch-z3)
+    add_library(smt-switch-z3 STATIC IMPORTED GLOBAL)
+    set_target_properties(smt-switch-z3 PROPERTIES IMPORTED_LOCATION "${SmtSwitch_z3_LIBRARY}")
+    # Prefer the Z3 build smt-switch's own contrib/setup-z3.sh installs into
+    # deps/install over any system-wide Z3 installation.
+    find_package(Z3 QUIET PATHS "${SMT_SWITCH_DIR}/deps/install" NO_DEFAULT_PATH)
+    if(NOT Z3_FOUND)
+      find_package(Z3 REQUIRED)
+    endif()
+    set_property(
+      TARGET smt-switch-z3
+      APPEND
+      PROPERTY INTERFACE_LINK_LIBRARIES smt-switch z3::libz3
+    )
+  endif()
+
+  foreach(_comp cvc5 btor msat yices2)
     if(_comp IN_LIST SmtSwitch_FIND_COMPONENTS AND NOT TARGET smt-switch-${_comp})
       add_library(smt-switch-${_comp} STATIC IMPORTED GLOBAL)
       set_target_properties(

--- a/cmake/FindSmtSwitch.cmake
+++ b/cmake/FindSmtSwitch.cmake
@@ -1,0 +1,135 @@
+#[=======================================================================[.rst:
+FindSmtSwitch
+-------------
+
+Finds an already-built smt-switch installation (https://github.com/stanford-centaur/smt-switch),
+as produced by its own ``./configure.sh --prefix=local ... && cmake --build . && cmake --install .``
+workflow (this is what ``contrib/setup-smt-switch.sh`` runs).
+
+smt-switch does not ship CMake package config files, so this module locates
+its headers/libraries directly and wraps them in imported targets. The
+target names deliberately match smt-switch's own (unnamespaced) CMake
+target names -- ``smt-switch``, ``smt-switch-bitwuzla``, etc. -- rather than
+using a ``SmtSwitch::`` namespace, so that a future in-tree build (e.g. via
+``add_subdirectory()`` on a FetchContent-fetched checkout, which defines
+targets with these exact names) can be swapped in without changing any
+``target_link_libraries()`` call sites.
+
+Hints
+^^^^^
+
+``SMT_SWITCH_DIR``
+  Root of a built smt-switch checkout, i.e. the directory passed as
+  ``--prefix=local`` was run from. Headers/libraries are expected under
+  ``${SMT_SWITCH_DIR}/local``. Bitwuzla's pkg-config files (built by
+  smt-switch's own ``contrib/setup-bitwuzla.sh``) are expected under
+  ``${SMT_SWITCH_DIR}/deps/install``.
+
+Components
+^^^^^^^^^^
+
+Each of ``bitwuzla``, ``cvc5``, ``btor``, ``msat``, ``yices2``, ``z3`` may be
+requested as a component. Only requested components are searched for and
+given imported targets.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+``smt-switch``
+  The core smt-switch library, always defined if found.
+
+``smt-switch-<component>``
+  One per requested/found component, e.g. ``smt-switch-bitwuzla``.
+
+Result Variables
+^^^^^^^^^^^^^^^^^
+
+``SmtSwitch_FOUND``
+  True if the core library and all requested components were found.
+
+``SmtSwitch_INCLUDE_DIR``
+  Directory containing the ``smt-switch/`` header directory (i.e. the
+  directory to add to the include path so that ``#include
+  "smt-switch/smt.h"`` resolves).
+#]=======================================================================]
+
+if(NOT DEFINED SMT_SWITCH_DIR)
+  set(SMT_SWITCH_DIR "${PROJECT_SOURCE_DIR}/deps/smt-switch")
+endif()
+
+find_path(SmtSwitch_INCLUDE_DIR NAMES smt-switch/smt.h HINTS "${SMT_SWITCH_DIR}/local/include")
+
+find_library(SmtSwitch_LIBRARY NAMES smt-switch HINTS "${SMT_SWITCH_DIR}/local/lib")
+
+set(_SmtSwitch_required_vars SmtSwitch_LIBRARY SmtSwitch_INCLUDE_DIR)
+
+# Components that need extra transitive link/include requirements beyond
+# just linking the core `smt-switch` target are handled individually below.
+foreach(_comp ${SmtSwitch_FIND_COMPONENTS})
+  find_library(
+    SmtSwitch_${_comp}_LIBRARY
+    NAMES smt-switch-${_comp}
+    HINTS "${SMT_SWITCH_DIR}/local/lib"
+  )
+  if(SmtSwitch_${_comp}_LIBRARY)
+    set(SmtSwitch_${_comp}_FOUND TRUE)
+  else()
+    set(SmtSwitch_${_comp}_FOUND FALSE)
+  endif()
+  list(APPEND _SmtSwitch_required_vars SmtSwitch_${_comp}_LIBRARY)
+endforeach()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  SmtSwitch
+  REQUIRED_VARS ${_SmtSwitch_required_vars}
+  HANDLE_COMPONENTS
+)
+
+if(SmtSwitch_FOUND AND NOT TARGET smt-switch)
+  add_library(smt-switch STATIC IMPORTED GLOBAL)
+  set_target_properties(
+    smt-switch
+    PROPERTIES
+      IMPORTED_LOCATION "${SmtSwitch_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${SmtSwitch_INCLUDE_DIR}"
+  )
+  find_package(Threads REQUIRED)
+  set_property(TARGET smt-switch APPEND PROPERTY INTERFACE_LINK_LIBRARIES Threads::Threads)
+
+  if("bitwuzla" IN_LIST SmtSwitch_FIND_COMPONENTS AND NOT TARGET smt-switch-bitwuzla)
+    add_library(smt-switch-bitwuzla STATIC IMPORTED GLOBAL)
+    set_target_properties(
+      smt-switch-bitwuzla
+      PROPERTIES IMPORTED_LOCATION "${SmtSwitch_bitwuzla_LIBRARY}"
+    )
+    find_package(PkgConfig REQUIRED)
+    list(APPEND CMAKE_PREFIX_PATH "${SMT_SWITCH_DIR}/deps/install")
+    pkg_check_modules(SMTSWITCH_BITWUZLA REQUIRED IMPORTED_TARGET bitwuzla)
+    set_property(
+      TARGET smt-switch-bitwuzla
+      APPEND
+      PROPERTY INTERFACE_LINK_LIBRARIES smt-switch PkgConfig::SMTSWITCH_BITWUZLA
+    )
+  endif()
+
+  foreach(
+    _comp
+    cvc5
+    btor
+    msat
+    yices2
+    z3
+  )
+    if(_comp IN_LIST SmtSwitch_FIND_COMPONENTS AND NOT TARGET smt-switch-${_comp})
+      add_library(smt-switch-${_comp} STATIC IMPORTED GLOBAL)
+      set_target_properties(
+        smt-switch-${_comp}
+        PROPERTIES IMPORTED_LOCATION "${SmtSwitch_${_comp}_LIBRARY}"
+      )
+      set_property(TARGET smt-switch-${_comp} APPEND PROPERTY INTERFACE_LINK_LIBRARIES smt-switch)
+    endif()
+  endforeach()
+endif()
+
+mark_as_advanced(SmtSwitch_INCLUDE_DIR SmtSwitch_LIBRARY)

--- a/cmake/FindSmtSwitch.cmake
+++ b/cmake/FindSmtSwitch.cmake
@@ -111,11 +111,23 @@ if(SmtSwitch_FOUND AND NOT TARGET smt-switch)
     )
     find_package(PkgConfig REQUIRED)
     list(APPEND CMAKE_PREFIX_PATH "${SMT_SWITCH_DIR}/deps/install")
-    pkg_check_modules(SMTSWITCH_BITWUZLA REQUIRED IMPORTED_TARGET bitwuzla)
+    # Deliberately not IMPORTED_TARGET: that mode resolves each transitive
+    # library name (e.g. mpfr, a public "Requires:" of bitwuzla.pc) via
+    # find_library(), which prefers .so over .a on Linux. That breaks fully
+    # static executables (PONO_STATIC_EXEC=YES) even when a static archive
+    # is available, since the linker is handed an explicit .so path instead
+    # of a bare -l flag it could resolve itself. Using the raw pkg-config
+    # flags string avoids that.
+    pkg_check_modules(SMTSWITCH_BITWUZLA REQUIRED bitwuzla)
     set_property(
       TARGET smt-switch-bitwuzla
       APPEND
-      PROPERTY INTERFACE_LINK_LIBRARIES smt-switch PkgConfig::SMTSWITCH_BITWUZLA
+      PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${SMTSWITCH_BITWUZLA_INCLUDE_DIRS}
+    )
+    set_property(
+      TARGET smt-switch-bitwuzla
+      APPEND
+      PROPERTY INTERFACE_LINK_LIBRARIES smt-switch "${SMTSWITCH_BITWUZLA_LDFLAGS}"
     )
   endif()
 

--- a/python/pono/CMakeLists.txt
+++ b/python/pono/CMakeLists.txt
@@ -27,4 +27,4 @@ add_custom_command(
 python_add_library(_pono_impl MODULE WITH_SOABI pono.cxx)
 target_link_libraries(_pono_impl PUBLIC pono-lib)
 # This has to be included because Cython uses the definitions from the smt-switch pxd files.
-target_include_directories(_pono_impl PRIVATE "${SMT_SWITCH_DIR}/local/include/smt-switch")
+target_include_directories(_pono_impl PRIVATE "${SmtSwitch_INCLUDE_DIR}/smt-switch")


### PR DESCRIPTION
Add cmake/FindSmtSwitch.cmake, a custom find-module that locates an already-built smt-switch installation and exposes it as imported targets named to match smt-switch's own (unnamespaced) CMake targets (smt-switch, smt-switch-bitwuzla, smt-switch-cvc5, etc.), including components for the optional boolector/mathsat/yices2/z3 backends and folding in bitwuzla's pkg-config lookup.

This removes every hardcoded reference to smt-switch's on-disk install layout (local/include, local/lib/*.a, deps/install) and the manual FATAL_ERROR existence checks from the top-level CMakeLists.txt, in favor of one find_package(SmtSwitch REQUIRED COMPONENTS ...) call and linking against the resulting targets. This is a pure build-system refactor with no change to the developer workflow (contrib/setup-smt-switch.sh still has to be run first); it sets up a later change to make find_package(SmtSwitch) fall back to FetchContent + an automated build when smt-switch isn't found, reusing the same target names.