### PR TITLE
Remove redundant pono-level pthread link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,7 +321,6 @@ endif()
 target_link_libraries(pono-lib PUBLIC smt-switch)
 target_link_libraries(pono-lib PUBLIC ${Btor2Tools_LIBRARIES})
 target_link_libraries(pono-lib PUBLIC "${GMPXX_LDFLAGS}")
-target_link_libraries(pono-lib PUBLIC pthread)
 
 if(GOOGLE_PERF)
   target_link_libraries(pono-lib PUBLIC ${GOOGLE_PERF})


### PR DESCRIPTION
pono's own source has no direct threading usage; the real dependency is smt-switch's core (portfolio_solver.cpp uses std::thread/std::mutex unconditionally), already handled by cmake/FindSmtSwitch.cmake linking Threads::Threads onto the smt-switch target. Since pono-lib links smt-switch, that requirement already propagates transitively -- the explicit pthread link here was redundant.

Verified with a full default build + test suite (26/26 passing) and a --static --with-btor --with-msat build, confirming the static executable still links and runs correctly without the explicit link.