### PR TITLE
Move GMP dependency handling into cmake/FindGMPXX.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,9 +83,7 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
-find_package(PkgConfig REQUIRED)
-
-pkg_check_modules(GMPXX REQUIRED gmpxx)
+find_package(GMPXX REQUIRED)
 
 set(SmtSwitch_FIND_COMPONENTS bitwuzla cvc5)
 if(WITH_BOOLECTOR)
@@ -160,7 +158,6 @@ set(
   ${Btor2Tools_INCLUDE_DIRS}
   # generated Bison headers go in build directory
   "${CMAKE_CURRENT_BINARY_DIR}"
-  ${GMPXX_INCLUDE_DIRS}
   ${FLEX_INCLUDE_DIRS}
 )
 
@@ -320,7 +317,7 @@ endif()
 
 target_link_libraries(pono-lib PUBLIC smt-switch)
 target_link_libraries(pono-lib PUBLIC ${Btor2Tools_LIBRARIES})
-target_link_libraries(pono-lib PUBLIC "${GMPXX_LDFLAGS}")
+target_link_libraries(pono-lib PUBLIC GMPXX::gmpxx)
 
 if(GOOGLE_PERF)
   target_link_libraries(pono-lib PUBLIC ${GOOGLE_PERF})

--- a/cmake/FindGMPXX.cmake
+++ b/cmake/FindGMPXX.cmake
@@ -1,0 +1,40 @@
+#[=======================================================================[.rst:
+FindGMPXX
+---------
+
+Finds the GNU Multiple Precision Arithmetic Library's C++ bindings
+(gmpxx) via pkg-config. GMP ships no CMake package config files, so this
+module locates it directly.
+
+Imported Targets
+^^^^^^^^^^^^^^^^^
+
+``GMPXX::gmpxx``
+  The gmpxx library, if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^^
+
+``GMPXX_FOUND``
+  True if gmpxx was found.
+#]=======================================================================]
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GMPXX QUIET gmpxx)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  GMPXX
+  REQUIRED_VARS GMPXX_LIBRARIES GMPXX_INCLUDE_DIRS
+  VERSION_VAR GMPXX_VERSION
+)
+
+if(GMPXX_FOUND AND NOT TARGET GMPXX::gmpxx)
+  add_library(GMPXX::gmpxx INTERFACE IMPORTED)
+  set_target_properties(
+    GMPXX::gmpxx
+    PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${GMPXX_INCLUDE_DIRS}"
+      INTERFACE_LINK_LIBRARIES "${GMPXX_LDFLAGS}"
+  )
+endif()

--- a/cmake/FindGMPXX.cmake
+++ b/cmake/FindGMPXX.cmake
@@ -25,7 +25,7 @@ pkg_check_modules(GMPXX QUIET gmpxx)
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   GMPXX
-  REQUIRED_VARS GMPXX_LIBRARIES GMPXX_INCLUDE_DIRS
+  REQUIRED_VARS GMPXX_INCLUDE_DIRS GMPXX_LDFLAGS
   VERSION_VAR GMPXX_VERSION
 )
 


### PR DESCRIPTION
The top-level CMakeLists.txt shouldn't need to know how to locate GMP's C++ bindings via pkg-config. This is the only inline pkg-config dependency in the main file (find_package(PkgConfig REQUIRED) exists solely for it).

Named FindGMPXX (not FindGMP) since pono only ever needs the C++ bindings specifically (gmpxx.pc's own "Requires: gmp" already pulls in the base library transitively) -- smt-switch ships its own, differently -scoped FindGMP.cmake for the base C library, which is not what's needed here. Target is GMPXX::gmpxx: uppercase namespace matching the module/package name, lowercase component matching the literal library name.

Deliberately not IMPORTED_TARGET: that mode resolves transitive libraries via find_library(), which prefers .so over .a and can break --static builds. gmpxx.pc's Requires chain is just gmp today, but keeping the plain-flags approach avoids reintroducing that footgun if it changes.

Verified with a full default build + test suite (26/26 passing) and a --static --with-btor --with-msat build (confirmed still statically linked and runs correctly).