### PR TITLE
build: stop wiping build dir/cache on every configure.sh run

### DIFF
--- a/cmake/FindSmtSwitch.cmake
+++ b/cmake/FindSmtSwitch.cmake
@@ -63,8 +63,14 @@ if(NOT DEFINED SMT_SWITCH_DIR)
   set(SMT_SWITCH_DIR "${PROJECT_SOURCE_DIR}/deps/smt-switch")
 endif()
 
+# These are cached (as find_path()/find_library() results always are), but
+# a cache hit from an earlier configure with a different SMT_SWITCH_DIR
+# would otherwise stick around unsearched. Unsetting first forces a fresh
+# search against the current SMT_SWITCH_DIR on every configure.
+unset(SmtSwitch_INCLUDE_DIR CACHE)
 find_path(SmtSwitch_INCLUDE_DIR NAMES smt-switch/smt.h HINTS "${SMT_SWITCH_DIR}/local/include")
 
+unset(SmtSwitch_LIBRARY CACHE)
 find_library(SmtSwitch_LIBRARY NAMES smt-switch HINTS "${SMT_SWITCH_DIR}/local/lib")
 
 set(_SmtSwitch_required_vars SmtSwitch_LIBRARY SmtSwitch_INCLUDE_DIR)
@@ -72,6 +78,7 @@ set(_SmtSwitch_required_vars SmtSwitch_LIBRARY SmtSwitch_INCLUDE_DIR)
 # Components that need extra transitive link/include requirements beyond
 # just linking the core `smt-switch` target are handled individually below.
 foreach(_comp ${SmtSwitch_FIND_COMPONENTS})
+  unset(SmtSwitch_${_comp}_LIBRARY CACHE)
   find_library(
     SmtSwitch_${_comp}_LIBRARY
     NAMES smt-switch-${_comp}

--- a/configure.sh
+++ b/configure.sh
@@ -36,23 +36,25 @@ die() {
   exit 1
 }
 
-build_dir=build
-smt_switch_dir=default
-install_prefix=default
+root_dir=$(pwd)
+
+build_dir=$root_dir/build
+smt_switch_dir=$root_dir/deps/smt-switch
+install_prefix=/usr/local
 build_type=Release
-with_boolector=default
-with_msat=default
-with_yices2=default
-with_z3=default
-with_msat_ic3ia=default
-with_coreir=default
-with_coreir_extern=default
-docs=default
-python=default
+with_boolector=OFF
+with_msat=OFF
+with_yices2=OFF
+with_z3=OFF
+with_msat_ic3ia=OFF
+with_coreir=OFF
+with_coreir_extern=OFF
+docs=OFF
+python=OFF
 lib_type=SHARED
 static_exec=NO
-with_profiling=default
-system_gtest=default
+with_profiling=OFF
+system_gtest=ON
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -63,8 +65,8 @@ while [[ $# -gt 0 ]]; do
       # Check if install_prefix is an absolute path and if not, make it
       # absolute.
       case $install_prefix in
-        /*) ;;                                      # absolute path
-        *) install_prefix=$(pwd)/$install_prefix ;; # make absolute path
+        /*) ;;                                         # absolute path
+        *) install_prefix=$root_dir/$install_prefix ;; # make absolute path
       esac
       ;;
     --build-dir) die "missing argument to $1 (see -h)" ;;
@@ -73,8 +75,8 @@ while [[ $# -gt 0 ]]; do
       # Check if build_dir is an absolute path and if not, make it
       # absolute.
       case $build_dir in
-        /*) ;;                            # absolute path
-        *) build_dir=$(pwd)/$build_dir ;; # make absolute path
+        /*) ;;                               # absolute path
+        *) build_dir=$root_dir/$build_dir ;; # make absolute path
       esac
       ;;
     --smt-switch-dir) die "missing argument to $1 (see -h)" ;;
@@ -82,8 +84,8 @@ while [[ $# -gt 0 ]]; do
       smt_switch_dir=${1##*=}
       # Check if this is an absolute path and if not, make it absolute.
       case $smt_switch_dir in
-        /*) ;;                                      # absolute path
-        *) smt_switch_dir=$(pwd)/$smt_switch_dir ;; # make absolute path
+        /*) ;;                                         # absolute path
+        *) smt_switch_dir=$root_dir/$smt_switch_dir ;; # make absolute path
       esac
       ;;
     --with-btor) with_boolector=ON ;;
@@ -96,9 +98,9 @@ while [[ $# -gt 0 ]]; do
     --debug)
       build_type=Debug
       ;;
-    --docs) docs=yes ;;
+    --docs) docs=ON ;;
     --python)
-      python=yes
+      python=ON
       ;;
     --static-lib)
       lib_type=STATIC
@@ -108,7 +110,7 @@ while [[ $# -gt 0 ]]; do
       lib_type=STATIC
       ;;
     --with-profiling) with_profiling=ON ;;
-    --no-system-gtest) system_gtest=no ;;
+    --no-system-gtest) system_gtest=OFF ;;
     *) die "unexpected argument: $1" ;;
   esac
   shift
@@ -117,56 +119,32 @@ done
 [[ $lib_type == STATIC ]] && { [[ $with_coreir == ON ]] || [[ $with_coreir_extern == ON ]]; } &&
   die "CoreIR and static build are incompatible, must omit either '--static/--static-lib' or '--with-coreir/--with-coreir-extern'"
 
-cmake_opts=(-DCMAKE_BUILD_TYPE="$build_type" -DPONO_LIB_TYPE="$lib_type" -DPONO_STATIC_EXEC="$static_exec")
-
-[[ $smt_switch_dir != default ]] &&
-  cmake_opts+=(-DSMT_SWITCH_DIR="$smt_switch_dir")
-
-[[ $install_prefix != default ]] &&
-  cmake_opts+=(-DCMAKE_INSTALL_PREFIX="$install_prefix")
-
-[[ $with_boolector != default ]] &&
-  cmake_opts+=(-DWITH_BOOLECTOR="$with_boolector")
-
-[[ $with_msat != default ]] &&
-  cmake_opts+=(-DWITH_MSAT="$with_msat")
-
-[[ $with_yices2 != default ]] &&
-  cmake_opts+=(-DWITH_YICES2="$with_yices2")
-
-[[ $with_z3 != default ]] &&
-  cmake_opts+=(-DWITH_Z3="$with_z3")
-
-[[ $with_msat_ic3ia != default ]] &&
-  cmake_opts+=(-DWITH_MSAT_IC3IA="$with_msat_ic3ia")
-
-[[ $with_coreir != default ]] &&
-  cmake_opts+=(-DWITH_COREIR="$with_coreir")
-
-[[ $with_coreir_extern != default ]] &&
-  cmake_opts+=(-DWITH_COREIR_EXTERN="$with_coreir_extern")
-
-[[ $docs != default ]] &&
-  cmake_opts+=(-DBUILD_DOCS=ON)
-
-[[ $python != default ]] &&
-  cmake_opts+=(-DBUILD_PYTHON_BINDINGS=ON)
-
-[[ $with_profiling != default ]] &&
-  cmake_opts+=(-DWITH_PROFILING="$with_profiling")
-
-[[ $system_gtest != default ]] &&
-  cmake_opts+=(-DSYSTEM_GTEST="$system_gtest")
-
-root_dir=$(pwd)
-
-[[ -e $build_dir ]] && rm -r "$build_dir"
-
-mkdir -p "$build_dir"
-cd "$build_dir" || exit 1
-
-[[ -e CMakeCache.txt ]] && rm CMakeCache.txt
+# Every option below is passed unconditionally, not just when it differs from
+# its default, so that re-running configure.sh on an existing build
+# directory always overwrites CMake's cache with the currently requested
+# value (e.g. omitting --with-z3 on a later run correctly turns it back off,
+# instead of leaving an earlier run's ON stuck in the cache). That in turn
+# means we don't have to wipe the build directory to get a correct
+# reconfigure.
+cmake_opts=(
+  -DCMAKE_BUILD_TYPE="$build_type"
+  -DPONO_LIB_TYPE="$lib_type"
+  -DPONO_STATIC_EXEC="$static_exec"
+  -DSMT_SWITCH_DIR="$smt_switch_dir"
+  -DCMAKE_INSTALL_PREFIX="$install_prefix"
+  -DWITH_BOOLECTOR="$with_boolector"
+  -DWITH_MSAT="$with_msat"
+  -DWITH_YICES2="$with_yices2"
+  -DWITH_Z3="$with_z3"
+  -DWITH_MSAT_IC3IA="$with_msat_ic3ia"
+  -DWITH_COREIR="$with_coreir"
+  -DWITH_COREIR_EXTERN="$with_coreir_extern"
+  -DBUILD_DOCS="$docs"
+  -DBUILD_PYTHON_BINDINGS="$python"
+  -DWITH_PROFILING="$with_profiling"
+  -DSYSTEM_GTEST="$system_gtest"
+)
 
 echo "Running with cmake options: ${cmake_opts[*]}"
 
-cmake "$root_dir" "${cmake_opts[@]}" 2>&1
+cmake -S "$root_dir" -B "$build_dir" "${cmake_opts[@]}" 2>&1


### PR DESCRIPTION
configure.sh only passed -D flags to cmake when they differed from its own defaults, so an omitted flag on a later run left an old cached value in place; and FindSmtSwitch.cmake's find_path/find_library calls trusted a cached hit even after SMT_SWITCH_DIR changed. Both were worked around by rm -r'ing the whole build directory (and CMakeCache.txt) on every run, discarding all incremental build state.

Fix both root causes instead: configure.sh now always emits every option's current value so cache entries are never stale-by-omission, and FindSmtSwitch.cmake unsets its cached find results before re-searching so a changed SMT_SWITCH_DIR is honored. configure.sh no longer touches the filesystem itself, delegating directory creation to `cmake -S -B`, and reconfiguring an existing build directory now correctly reuses it instead of forcing a full rebuild.