### PR TITLE
fix: build the docs target automatically with ALL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,6 +358,7 @@ if(BUILD_DOCS)
   find_package(Doxygen)
   doxygen_add_docs(
     docs
+    ALL
     core/
     engines/
     frontends/


### PR DESCRIPTION
doxygen_add_docs(docs ...) had no ALL, so --docs/-DBUILD_DOCS=ON only registered a "docs" target that had to be built separately via `ninja docs` -- the default build never generated documentation despite --docs's help text ("build HTML documentation with Doxygen") implying otherwise. Adding ALL makes docs a dependency of the default "all" target, matching that description.