### PR TITLE
build: Enforce a max line length for shell scripts via bashate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,15 @@ repos:
     rev: v0.11.0.1
     hooks:
       - id: shellcheck
+  - repo: https://github.com/openstack/bashate
+    rev: "2.1.1"
+    hooks:
+      - id: bashate
+        # E003 (4-space indents) and E020 (function name {} declarations)
+        # conflict with this repo's conventions (2-space indents, name() {}).
+        # --error E treats every check as an error rather than a
+        # non-failing warning (all bashate codes start with "E").
+        args: [--ignore, "E003,E020", --error, "E"]
   - repo: https://github.com/google/yamlfmt
     rev: v0.21.0
     hooks:

--- a/ci-scripts/setup-msat.sh
+++ b/ci-scripts/setup-msat.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-DEPS=$DIR/../deps
-
-mkdir -p "$DEPS"
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+dir="$dir/../deps/mathsat"
 
 usage() {
   cat <<EOF
@@ -20,7 +18,7 @@ EOF
 
 get_msat=default
 msat_version="5.6.12"
-mast_release_url="https://mathsat.fbk.eu/release"
+msat_release_url="https://mathsat.fbk.eu/release/mathsat"
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -32,7 +30,10 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ $get_msat == default ]]; then
-  read -rp "MathSAT is distributed under a custom (non-BSD compliant) license. By continuing you acknowledge this distinction and assume responsibility for meeting the license conditions. Continue? [y]es/[n]o: " get_msat
+  read -rp "MathSAT is distributed under a custom (non-BSD compliant) ""\
+license. By continuing you acknowledge this distinction and assume ""\
+responsibility for meeting the license conditions. Continue? ""\
+[y]es/[n]o: " get_msat
 fi
 
 if [[ $get_msat != y ]]; then
@@ -40,32 +41,32 @@ if [[ $get_msat != y ]]; then
   exit 0
 fi
 
-if [[ ! -d "$DEPS/mathsat" ]]; then
-  cd "$DEPS"
-  mkdir mathsat
+if [[ ! -d $dir ]]; then
+  mkdir -p "$dir"
+  cd "$dir"
   if [[ $OSTYPE == linux* ]]; then
-    wget -O mathsat.tar.gz $mast_release_url/mathsat-$msat_version-linux-x86_64.tar.gz
+    wget -O mathsat.tar.gz $msat_release_url-$msat_version-linux-x86_64.tar.gz
   elif [[ $OSTYPE == darwin* ]]; then
-    wget -O mathsat.tar.gz $mast_release_url/mathsat-$msat_version-macos.tar.gz
+    wget -O mathsat.tar.gz $msat_release_url-$msat_version-macos.tar.gz
   elif [[ $OSTYPE == msys* ]]; then
-    wget -O mathsat.tar.gz $mast_release_url/mathsat-$msat_version-win64-msvc.zip
+    wget -O mathsat.tar.gz $msat_release_url-$msat_version-win64-msvc.zip
   elif [[ $OSTYPE == cygwin* ]]; then
-    wget -O mathsat.tar.gz $mast_release_url/mathsat-$msat_version-linux-x86_64.tar.gz
+    wget -O mathsat.tar.gz $msat_release_url-$msat_version-linux-x86_64.tar.gz
   else
     echo "Unrecognized OSTYPE=$OSTYPE"
     exit 1
   fi
 
-  tar -xf mathsat.tar.gz -C mathsat --strip-components 1
+  tar -xf mathsat.tar.gz --strip-components 1
   rm mathsat.tar.gz
 
 else
-  echo "$DEPS/mathsat already exists. If you want to re-download, please remove it manually."
+  echo "$dir already exists. If you want to re-download, please remove it."
 fi
 
-if [[ -f "$DEPS/mathsat/lib/libmathsat.a" ]]; then
-  echo "It appears mathsat was setup successfully into $DEPS/mathsat."
-  echo "You may now install it with make ./configure.sh --msat && cd build && make"
+if [[ -f "$dir/lib/libmathsat.a" ]]; then
+  echo "It appears mathsat was setup successfully into $dir."
+  echo "You may now install it with ./configure.sh --msat && cd build && make"
 else
   echo "Downloading mathsat failed."
   echo "Please see their website: http://mathsat.fbk.eu/"

--- a/configure.sh
+++ b/configure.sh
@@ -136,8 +136,10 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-[[ $lib_type == STATIC ]] && { [[ $with_coreir == ON ]] || [[ $with_coreir_extern == ON ]]; } &&
-  die "CoreIR and static build are incompatible, must omit either '--static/--static-lib' or '--with-coreir/--with-coreir-extern'"
+[[ $lib_type == STATIC ]] &&
+  { [[ $with_coreir == ON ]] || [[ $with_coreir_extern == ON ]]; } &&
+  die "CoreIR and static build are incompatible, must omit either" \
+    "'--static/--static-lib' or '--with-coreir/--with-coreir-extern'"
 
 # Every option below is passed unconditionally, not just when it differs from
 # its default, so that re-running configure.sh on an existing build

--- a/contrib/setup-btor2tools.sh
+++ b/contrib/setup-btor2tools.sh
@@ -19,7 +19,8 @@ if [[ ! -d "$DEPS/btor2tools" ]]; then
   cmake --install . --prefix "$DEPS/install"
   cd "$DIR"
 else
-  echo "$DEPS/btor2tools already exists. If you want to rebuild, please remove it manually."
+  echo "$DEPS/btor2tools already exists. If you want to rebuild, please" \
+    "remove it manually."
 fi
 
 if [[ -f "$DEPS/install/lib/libbtor2parser.a" ]]; then
@@ -28,6 +29,7 @@ if [[ -f "$DEPS/install/lib/libbtor2parser.a" ]]; then
 else
   echo "Building btor2tools failed."
   echo "You might be missing some dependencies."
-  echo "Please see their github page for installation instructions: https://github.com/Boolector/btor2tools.git"
+  echo "Please see their github page for installation instructions:" \
+    "https://github.com/Boolector/btor2tools.git"
   exit 1
 fi

--- a/contrib/setup-coreir.sh
+++ b/contrib/setup-coreir.sh
@@ -53,7 +53,8 @@ if [[ ! -d "$DEPS/coreir" ]]; then
     cd pycoreir
     export PATH=$PATH:$DEPS/coreir/local/bin
     if ! command -v coreir; then
-      echo "It looks like building CoreIR failed. Unable to find coreir binary in $DEPS/coreir/local/bin."
+      echo "It looks like building CoreIR failed. Unable to find coreir" \
+        "binary in $DEPS/coreir/local/bin."
       echo "Cannot install coreir python bindings without locating binary."
       exit 1
     fi
@@ -62,7 +63,8 @@ if [[ ! -d "$DEPS/coreir" ]]; then
   cd "$DIR"
   cd ../
 else
-  echo "$DEPS/coreir already exists. If you want to rebuild, please remove it manually."
+  echo "$DEPS/coreir already exists. If you want to rebuild, please" \
+    "remove it manually."
 fi
 
 if [[ -f "$DEPS/coreir/local/lib/libcoreir.so" ]]; then
@@ -71,6 +73,7 @@ if [[ -f "$DEPS/coreir/local/lib/libcoreir.so" ]]; then
 else
   echo "Building coreir failed."
   echo "You might be missing some dependencies."
-  echo "Please see their github page for installation instructions:https://github.com/rdaly525/coreir"
+  echo "Please see their github page for installation instructions:" \
+    "https://github.com/rdaly525/coreir"
   exit 1
 fi

--- a/contrib/setup-ic3ia.sh
+++ b/contrib/setup-ic3ia.sh
@@ -57,7 +57,8 @@ if [[ ! -d $msat_home ]]; then
   exit 1
 fi
 
-curl -Lk https://es-static.fbk.eu/people/griggio/ic3ia/$ic3ia_version.tar.gz --output "$DEPS/$ic3ia_version.tar.gz"
+curl -Lk https://es-static.fbk.eu/people/griggio/ic3ia/$ic3ia_version.tar.gz \
+  --output "$DEPS/$ic3ia_version.tar.gz"
 
 if [[ ! -f "$DEPS/$ic3ia_version.tar.gz" ]]; then
   echo "It appears that downloading ic3ia failed."

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -43,24 +43,24 @@ while (($# > 0)); do
     --with-msat)
       conf_opts+=(--msat --msat-home="$(pwd)/deps/mathsat")
       incl_solver_str="mathsat, $incl_solver_str"
-      ((num_of_libs++))
+      : $((num_of_libs++))
       ;;
     --with-btor)
       with_boolector=true
       conf_opts+=(--btor)
       incl_solver_str="boolector, $incl_solver_str"
-      ((num_of_libs++))
+      : $((num_of_libs++))
       ;;
     --with-yices2)
       conf_opts+=(--yices2)
       incl_solver_str="yices2, $incl_solver_str"
-      ((num_of_libs++))
+      : $((num_of_libs++))
       ;;
     --with-z3)
       with_z3=true
       conf_opts+=(--z3)
       incl_solver_str="z3, $incl_solver_str"
-      ((num_of_libs++))
+      : $((num_of_libs++))
       ;;
     --python)
       conf_opts+=(--python)
@@ -88,7 +88,8 @@ if [[ ! -d smt-switch ]]; then
   git clone https://github.com/stanford-centaur/smt-switch
 fi
 cd smt-switch
-git checkout -f "$smt_switch_version" || echo "warning: smt-switch folder is not a git repo"
+git checkout -f "$smt_switch_version" ||
+  echo "warning: smt-switch folder is not a git repo"
 
 # Build dependencies
 ./contrib/setup-bitwuzla.sh
@@ -104,9 +105,11 @@ fi
 
 # Configure, build, test, and install smt-switch
 if [[ -d build ]]; then
-  echo "$(pwd)/build already exists, please remove it manually if you want to reconfigure smt-switch"
+  echo "$(pwd)/build already exists, please remove it manually if you" \
+    "want to reconfigure smt-switch"
 else
-  ./configure.sh --prefix=local --static --smtlib-reader --bitwuzla --cvc5 ${conf_opts[@]+"${conf_opts[@]}"}
+  ./configure.sh --prefix=local --static --smtlib-reader --bitwuzla --cvc5 \
+    ${conf_opts[@]+"${conf_opts[@]}"}
 fi
 cd build
 cmake --build . -j
@@ -117,11 +120,14 @@ cd ..
 # Check that library files are there
 lib_files=(local/lib/libsmt-switch*)
 if ((${#lib_files[@]} == num_of_libs)); then
-  echo "Smt-switch with $incl_solver_str was successfully installed to $(pwd)/local."
-  echo "You may now build pono with: ./configure.sh && cd build && cmake --build ."
+  echo "Smt-switch with $incl_solver_str was successfully installed to" \
+    "$(pwd)/local."
+  echo "You may now build pono with: ./configure.sh && cd build && cmake" \
+    "--build ."
 else
   echo "Building smt-switch failed."
   echo "You might be missing some dependencies."
-  echo "Please see the github page for installation instructions: https://github.com/stanford-centaur/smt-switch"
+  echo "Please see the github page for installation instructions:" \
+    "https://github.com/stanford-centaur/smt-switch"
   exit 1
 fi


### PR DESCRIPTION
Add openstack/bashate as a pre-commit hook to enforce E006 (line too long, 79 columns) across all shell scripts. Ignore E003 (4-space indents) and E020 (function name {} declarations), which conflict with this repo's own conventions (2-space indents via shfmt, name() {} declarations). --error E promotes every check to an error, since E006 and a few others default to non-failing warnings.

Fix the resulting violations:
- configure.sh, setup-btor2tools.sh, setup-coreir.sh, setup-ic3ia.sh, setup-smt-switch.sh: wrap long echo/die messages and command invocations, mostly by splitting into multiple string arguments (echo/die join args with a space) or backslash-continuing before a long argument.
- setup-smt-switch.sh: replace `((num_of_libs++))` with `: $((num_of_libs++))` for the four solver-count increments. The bare form's exit status is the pre-increment value, which would trip `set -e` if num_of_libs were ever 0 before an increment; wrapping in `:` (always succeeds) avoids that while keeping the increment.
- setup-msat.sh: merge the DIR/DEPS variables into a single `dir` pointing directly at $DEPS/mathsat, and fold the repeated "/mathsat" path segment into msat_release_url (also fixing its "mast_" typo). This shrinks every message enough to avoid wrapping, and replaces the unconditional `mkdir -p "$DEPS"` (which created an empty deps/ even if the user declined the license prompt or passed --help) with `mkdir -p "$dir"` done only once a download is actually about to happen. Also fixes a stray "make" before "./configure.sh" in the final install message, and drops "manually" from the "already exists" message.
- setup-coreir.sh: fix a missing space before a URL in one message.