### PR TITLE
Fix bison and flex setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,16 +33,9 @@ jobs:
             libmpfr-dev \
             cmake \
             ninja-build
-      - name: Install Packages (macOS)
+      - name: Install bison (macOS)
         if: runner.os == 'macOS'
-        run: |
-          brew update
-          brew install \
-            bison \
-            flex
-          echo "PATH=$(brew --prefix)/opt/bison/bin:$(brew --prefix)/opt/flex/bin:$PATH" >> "$GITHUB_ENV"
-          echo "CMAKE_PREFIX_PATH=$(brew --prefix)/opt/flex" >> "$GITHUB_ENV"
-          echo "CPATH=$(brew --prefix)/include" >> "$GITHUB_ENV"
+        run: contrib/setup-bison.sh
       - name: Python Environment Setup
         run: |
           python3 -m venv ./.venv
@@ -58,6 +51,7 @@ jobs:
         run: ./contrib/setup-btor2tools.sh
       - name: Setup Smt-Switch
         env:
+          CPATH: /opt/homebrew/include # let libpoly (from cvc5) find gmp headers
           DYLD_FALLBACK_LIBRARY_PATH: /opt/homebrew/lib # this lets the precompiled MathSAT binary (used in the tests) find libgmp
         run: |
           source .venv/bin/activate

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,22 +64,23 @@ if(WITH_PROFILING)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWITH_PROFILING")
 endif()
 
-if(APPLE)
-  list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/bison")
-  list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/flex")
+# Try to find our custom bison build, falling back to Homebrew.
+if(IS_DIRECTORY "${PROJECT_SOURCE_DIR}/deps/bison-install")
+  set(BISON_ROOT "${PROJECT_SOURCE_DIR}/deps/bison-install")
+else()
+  execute_process(
+    COMMAND brew --prefix
+    RESULT_VARIABLE HOMEBREW_RESULT
+    OUTPUT_VARIABLE HOMEBREW_PREFIX
+    OUTPUT_QUIET
+    ERROR_QUIET
+  )
+  if(HOMEBREW_RESULT EQUAL 0 AND IS_DIRECTORY "${HOMEBREW_PREFIX}/opt/bison")
+    set(BISON_ROOT "${HOMEBREW_PREFIX}/opt/bison")
+  endif()
 endif()
-
 find_package(BISON 3.4.2 REQUIRED)
-if(BISON_FOUND)
-  get_filename_component(BISON_PARENT_DIR "${BISON_EXECUTABLE}" DIRECTORY)
-  message("-- Adding bison lib: ${BISON_PARENT_DIR}/../lib")
-  link_directories("${BISON_PARENT_DIR}/../lib/")
-endif()
-
 find_package(FLEX 2.6.4 REQUIRED)
-if(NOT FLEX_INCLUDE_DIRS)
-  message(FATAL_ERROR "Missing flex headers")
-endif()
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
@@ -158,7 +159,6 @@ set(
   ${Btor2Tools_INCLUDE_DIRS}
   # generated Bison headers go in build directory
   "${CMAKE_CURRENT_BINARY_DIR}"
-  ${FLEX_INCLUDE_DIRS}
 )
 
 set(

--- a/README.md
+++ b/README.md
@@ -24,10 +24,12 @@ generation of [CoSA](https://github.com/cristian-mattarei/CoSA) and thus was ori
 
 ## Setup
 
-* [optional] Install bison and flex
-  * If you don't have flex installed globally, run `./contrib/setup-flex.sh`
-  * Bison should be available in your OS package manager (Linux) or Homebrew (macOS).
-* Run `./contrib/setup-smt-switch.sh` -- it will build smt-switch with Bitwuzla
+* Run `./contrib/setup-smt-switch.sh` -- it will build smt-switch with Bitwuzla, cvc5, and the SMT-LIB reader
+  * Note: The SMT-LIB reader requires bison >=3.7 and flex >=2.6.4.
+    * On Linux these can usually be obtained from the distribution using `apt`, `dnf`, `pacman`, or similar.
+    * The command-line tools for XCode on macOS provide flex but the provided bison version is too old.
+    * We include the `contrib/setup-bison.sh` script that can be used to install a more up-to-date version.
+    * Alternatively, Homebrew can also be used to install a newer version of bison.
   * [optional] to build with MathSAT (required for interpolation-based model checking) you need to obtain the libraries yourself
     * note that MathSAT is under a custom non-BSD compliant license and you must assume all responsibility for meeting the conditions
     * download the solver from https://mathsat.fbk.eu/download.html, unpack it and rename the directory to `./deps/mathsat`

--- a/contrib/setup-bison.sh
+++ b/contrib/setup-bison.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version=3.8.2
+url=https://mirrors.ocf.berkeley.edu/gnu/bison
+dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)/deps/bison
+if [[ -d $dir ]]; then
+  echo "$dir already exists; remove it if you want to redownload bison" && exit
+fi
+archive=bison-$version.tar.gz
+curl -LsS -o $archive $url/$archive
+mkdir -p "$dir"
+tar -xf $archive -C "$dir" --strip-components 1
+rm -f $archive
+cd "$dir" && ./configure --prefix "$dir-install" && make && make install

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -109,7 +109,7 @@ if [[ -d build ]]; then
     "want to reconfigure smt-switch"
 else
   ./configure.sh --prefix=local --static --smtlib-reader --bitwuzla --cvc5 \
-    ${conf_opts[@]+"${conf_opts[@]}"}
+    --bison-dir=../bison-install ${conf_opts[@]+"${conf_opts[@]}"}
 fi
 cd build
 cmake --build . -j


### PR DESCRIPTION
* Re-add `setup-bison.sh` script, because the default bison (from Xcode) is too old on macOS.
* Test the script in ci (and remove the Homebrew install step).
* Make CMake automatically detect the custom bison install, or if there is none, the Homebrew-provided one.
* Point the smt-switch setup script to the custom bison install.
* Update project README to reflect the changes.
* Remove all references to custom flex paths that are no longer in use.