### PR TITLE
build: Take dependency install prefixes instead of source trees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,8 @@ pytest tests
 
 Key configure options: `--debug`, `--python`, `--with-msat`, `--with-yices2`, `--with-z3`, `--with-btor`, `--docs`, `--static`.
 
+Dependency locations default to the `deps/` layout the `contrib/` scripts produce, and are overridden with `--smt-switch-dir`, `--bitwuzla-dir`, `--msat-dir`, and `--z3-dir`, each taking an install prefix. These map to `<Package>_ROOT` CMake variables; `configure.sh` is the only place their defaults live.
+
 ## Architecture
 
 **Data flow:** Parse input → TransitionSystem → Apply modifiers → Choose prover engine → Unroll + send to SMT solver → Produce witness or proof.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,14 @@ find_package(FLEX 2.6.4 REQUIRED)
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
+# Install prefixes of the dependencies pono locates itself. Declared with an
+# empty default so that configure.sh stays the one place defaults live, and so
+# that leaving a backend disabled does not warn about an unused -D setting.
+set(Bitwuzla_ROOT "" CACHE PATH "bitwuzla install prefix")
+set(MathSAT_ROOT "" CACHE PATH "MathSAT install prefix")
+set(SmtSwitch_ROOT "" CACHE PATH "smt-switch install prefix")
+set(Z3_ROOT "" CACHE PATH "Z3 install prefix")
+
 find_package(GMPXX REQUIRED)
 
 set(SmtSwitch_FIND_COMPONENTS bitwuzla cvc5)
@@ -249,16 +257,23 @@ if(WITH_COREIR OR WITH_COREIR_EXTERN)
   set(SOURCES "${SOURCES}" "${PROJECT_SOURCE_DIR}/frontends/coreir_encoder.cpp")
 endif()
 
-if(WITH_MSAT)
+if(WITH_MSAT OR WITH_MSAT_IC3IA)
+  # MathSAT has no CMake module yet, so MathSAT_ROOT is checked by hand.
+  if(NOT EXISTS "${MathSAT_ROOT}/include/mathsat.h")
+    message(
+      FATAL_ERROR
+      "Missing MathSAT headers. Set --msat-dir to a MathSAT install prefix "
+      "containing include/mathsat.h (searched: ${MathSAT_ROOT})"
+    )
+  endif()
   # need direct access to mathsat for setting options
-  set(INCLUDE_DIRS "${INCLUDE_DIRS}" "${PROJECT_SOURCE_DIR}/deps/mathsat/include/")
+  set(INCLUDE_DIRS "${INCLUDE_DIRS}" "${MathSAT_ROOT}/include/")
 endif()
 
 if(WITH_MSAT_IC3IA)
   add_definitions(-DWITH_MSAT_IC3IA)
   # can't include ic3ia directly because some names clash e.g. ic3.h
   set(INCLUDE_DIRS "${INCLUDE_DIRS}" "${PROJECT_SOURCE_DIR}/deps/")
-  set(INCLUDE_DIRS "${INCLUDE_DIRS}" "${PROJECT_SOURCE_DIR}/deps/mathsat/include/")
   set(SOURCES "${SOURCES}" "${PROJECT_SOURCE_DIR}/engines/msat_ic3ia.cpp")
 endif()
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,12 @@ generation of [CoSA](https://github.com/cristian-mattarei/CoSA) and thus was ori
     * Alternatively, Homebrew can also be used to install a newer version of bison.
   * [optional] to build with MathSAT (required for interpolation-based model checking) you need to obtain the libraries yourself
     * note that MathSAT is under a custom non-BSD compliant license and you must assume all responsibility for meeting the conditions
-    * download the solver from https://mathsat.fbk.eu/download.html, unpack it and rename the directory to `./deps/mathsat`
-    * then add the `--with-msat` flag to the `setup-smt-switch.sh` command.
+    * download the solver from https://mathsat.fbk.eu/download.html and unpack it
+    * then add the `--with-msat` flag to the `setup-smt-switch.sh` command, along with `--msat-dir=<path>` unless you renamed the unpacked directory to `./deps/mathsat`
 * Run `./contrib/setup-btor2tools.sh`.
 * Run `./configure.sh`.
   * if building with mathsat, also include `--with-msat` as an option to `configure.sh`
+  * to build against dependencies installed elsewhere, pass their install prefixes with `--smt-switch-dir`, `--bitwuzla-dir`, `--msat-dir`, and `--z3-dir`; `setup-smt-switch.sh` prints the ones you need to repeat
 * Run `cd build`.
 * Run `make`.
 * [optional] Run `make check` to build and run the tests.

--- a/cmake/FindSmtSwitch.cmake
+++ b/cmake/FindSmtSwitch.cmake
@@ -3,7 +3,7 @@ FindSmtSwitch
 -------------
 
 Finds an already-built smt-switch installation (https://github.com/stanford-centaur/smt-switch),
-as produced by its own ``./configure.sh --prefix=local ... && cmake --build . && cmake --install .``
+as produced by its own ``./configure.sh --prefix=... && cmake --build . && cmake --install .``
 workflow (this is what ``contrib/setup-smt-switch.sh`` runs).
 
 smt-switch does not ship CMake package config files, so this module locates
@@ -18,18 +18,27 @@ targets with these exact names) can be swapped in without changing any
 Hints
 ^^^^^
 
-``SMT_SWITCH_DIR``
-  Root of a built smt-switch checkout, i.e. the directory passed as
-  ``--prefix=local`` was run from. Headers/libraries are expected under
-  ``${SMT_SWITCH_DIR}/local``. Bitwuzla's pkg-config files (built by
-  smt-switch's own ``contrib/setup-bitwuzla.sh``) are expected under
-  ``${SMT_SWITCH_DIR}/deps/install``.
+``SmtSwitch_ROOT``
+  An smt-switch install prefix, i.e. the directory passed to smt-switch's own
+  ``--prefix``. Headers and libraries are expected directly under
+  ``${SmtSwitch_ROOT}/include`` and ``${SmtSwitch_ROOT}/lib``. Being CMake's
+  standard install prefix variable, it needs no explicit ``HINTS`` below:
+  ``find_package()`` searches it ahead of ``CMAKE_PREFIX_PATH`` and the
+  system paths.
+
+``Bitwuzla_ROOT``
+  A bitwuzla install prefix, containing ``lib/pkgconfig/bitwuzla.pc``.
+  smt-switch's own ``contrib/setup-bitwuzla.sh`` installs one into
+  ``<smt-switch checkout>/deps/install``. Only consulted when the
+  ``bitwuzla`` component is requested, and applied by hand rather than by
+  ``find_package()``, since bitwuzla is located with pkg-config.
 
 Requesting the ``z3`` component additionally requires a Z3 installation
 discoverable via its own CMake package config, since smt-switch's own Z3
-backend links against it directly. smt-switch's own ``contrib/setup-z3.sh``
-installs Z3 into ``${SMT_SWITCH_DIR}/deps/install``; that location is always
-preferred over a system-wide Z3 installation if both are present.
+backend links against it directly. Set ``Z3_ROOT`` to select one;
+smt-switch's own ``contrib/setup-z3.sh`` installs Z3 into
+``<smt-switch checkout>/deps/install``. ``Z3_ROOT`` is searched before any
+system-wide Z3 installation.
 
 Components
 ^^^^^^^^^^
@@ -59,19 +68,15 @@ Result Variables
   "smt-switch/smt.h"`` resolves).
 #]=======================================================================]
 
-if(NOT DEFINED SMT_SWITCH_DIR)
-  set(SMT_SWITCH_DIR "${PROJECT_SOURCE_DIR}/deps/smt-switch")
-endif()
-
 # These are cached (as find_path()/find_library() results always are), but
-# a cache hit from an earlier configure with a different SMT_SWITCH_DIR
+# a cache hit from an earlier configure with a different SmtSwitch_ROOT
 # would otherwise stick around unsearched. Unsetting first forces a fresh
-# search against the current SMT_SWITCH_DIR on every configure.
+# search against the current SmtSwitch_ROOT on every configure.
 unset(SmtSwitch_INCLUDE_DIR CACHE)
-find_path(SmtSwitch_INCLUDE_DIR NAMES smt-switch/smt.h HINTS "${SMT_SWITCH_DIR}/local/include")
+find_path(SmtSwitch_INCLUDE_DIR NAMES smt-switch/smt.h)
 
 unset(SmtSwitch_LIBRARY CACHE)
-find_library(SmtSwitch_LIBRARY NAMES smt-switch HINTS "${SMT_SWITCH_DIR}/local/lib")
+find_library(SmtSwitch_LIBRARY NAMES smt-switch)
 
 set(_SmtSwitch_required_vars SmtSwitch_LIBRARY SmtSwitch_INCLUDE_DIR)
 
@@ -79,11 +84,7 @@ set(_SmtSwitch_required_vars SmtSwitch_LIBRARY SmtSwitch_INCLUDE_DIR)
 # just linking the core `smt-switch` target are handled individually below.
 foreach(_comp ${SmtSwitch_FIND_COMPONENTS})
   unset(SmtSwitch_${_comp}_LIBRARY CACHE)
-  find_library(
-    SmtSwitch_${_comp}_LIBRARY
-    NAMES smt-switch-${_comp}
-    HINTS "${SMT_SWITCH_DIR}/local/lib"
-  )
+  find_library(SmtSwitch_${_comp}_LIBRARY NAMES smt-switch-${_comp})
   if(SmtSwitch_${_comp}_LIBRARY)
     set(SmtSwitch_${_comp}_FOUND TRUE)
   else()
@@ -91,6 +92,18 @@ foreach(_comp ${SmtSwitch_FIND_COMPONENTS})
   endif()
   list(APPEND _SmtSwitch_required_vars SmtSwitch_${_comp}_LIBRARY)
 endforeach()
+
+# SmtSwitch_ROOT used to be SMT_SWITCH_DIR and took the root of a built
+# smt-switch checkout rather than an install prefix, so catch a value that
+# still looks like one instead of reporting it as simply not found.
+if(NOT SmtSwitch_INCLUDE_DIR AND EXISTS "${SmtSwitch_ROOT}/local/include/smt-switch/smt.h")
+  message(
+    FATAL_ERROR
+    "No smt-switch installation at ${SmtSwitch_ROOT}, but one exists at "
+    "${SmtSwitch_ROOT}/local. This now takes an install prefix rather than "
+    "the checkout it was built from. Try --smt-switch-dir=${SmtSwitch_ROOT}/local"
+  )
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
@@ -117,7 +130,11 @@ if(SmtSwitch_FOUND AND NOT TARGET smt-switch)
       PROPERTIES IMPORTED_LOCATION "${SmtSwitch_bitwuzla_LIBRARY}"
     )
     find_package(PkgConfig REQUIRED)
-    list(APPEND CMAKE_PREFIX_PATH "${SMT_SWITCH_DIR}/deps/install")
+    # pkg_check_modules() is not a find_*() command, so it does not consult
+    # Bitwuzla_ROOT on its own; it does search CMAKE_PREFIX_PATH.
+    if(Bitwuzla_ROOT)
+      list(APPEND CMAKE_PREFIX_PATH "${Bitwuzla_ROOT}")
+    endif()
     # Deliberately not IMPORTED_TARGET: that mode resolves each transitive
     # library name (e.g. mpfr, a public "Requires:" of bitwuzla.pc) via
     # find_library(), which prefers .so over .a on Linux. That breaks fully
@@ -125,7 +142,14 @@ if(SmtSwitch_FOUND AND NOT TARGET smt-switch)
     # is available, since the linker is handed an explicit .so path instead
     # of a bare -l flag it could resolve itself. Using the raw pkg-config
     # flags string avoids that.
-    pkg_check_modules(SMTSWITCH_BITWUZLA REQUIRED bitwuzla)
+    pkg_check_modules(SMTSWITCH_BITWUZLA bitwuzla)
+    if(NOT SMTSWITCH_BITWUZLA_FOUND)
+      message(
+        FATAL_ERROR
+        "Could not find bitwuzla.pc. Set --bitwuzla-dir to a bitwuzla install "
+        "prefix containing lib/pkgconfig/bitwuzla.pc (searched: ${Bitwuzla_ROOT})"
+      )
+    endif()
     set_property(
       TARGET smt-switch-bitwuzla
       APPEND
@@ -141,11 +165,17 @@ if(SmtSwitch_FOUND AND NOT TARGET smt-switch)
   if("z3" IN_LIST SmtSwitch_FIND_COMPONENTS AND NOT TARGET smt-switch-z3)
     add_library(smt-switch-z3 STATIC IMPORTED GLOBAL)
     set_target_properties(smt-switch-z3 PROPERTIES IMPORTED_LOCATION "${SmtSwitch_z3_LIBRARY}")
-    # Prefer the Z3 build smt-switch's own contrib/setup-z3.sh installs into
-    # deps/install over any system-wide Z3 installation.
-    find_package(Z3 QUIET PATHS "${SMT_SWITCH_DIR}/deps/install" NO_DEFAULT_PATH)
+    # Z3_ROOT is searched ahead of CMAKE_PREFIX_PATH and the system paths.
+    # Clear the cached config directory first, or an earlier configure's Z3
+    # would survive a change of Z3_ROOT.
+    unset(Z3_DIR CACHE)
+    find_package(Z3 QUIET)
     if(NOT Z3_FOUND)
-      find_package(Z3 REQUIRED)
+      message(
+        FATAL_ERROR
+        "Could not find Z3Config.cmake. Set --z3-dir to a Z3 install prefix "
+        "containing lib/cmake/z3 (searched: ${Z3_ROOT})"
+      )
     endif()
     set_property(
       TARGET smt-switch-z3

--- a/configure.sh
+++ b/configure.sh
@@ -5,8 +5,9 @@ root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 build_dir=$root_dir/build
 
 # These variables, the flags in usage(), and the case statement below should
-# stay grouped by type (directory settings, build flags, optional features),
-# alphabetical within each group, and in sync with each other.
+# stay in sync, grouped by type (build/install directories, dependency
+# locations, build flags, optional features), and alphabetical within each
+# group.
 #
 # There is one cm_-prefixed variable per CMake variable. These should ideally
 # be in a single associative array, but macOS's default bash (3.2) doesn't
@@ -14,9 +15,19 @@ build_dir=$root_dir/build
 # prefix lets the final -D flag loop enumerate them all via ${!cm_@} without a
 # separately-maintained list of names.
 
-# Directory settings
+# Build and install directories
 cm_CMAKE_INSTALL_PREFIX=/usr/local
-cm_SMT_SWITCH_DIR="$root_dir/deps/smt-switch"
+
+# Dependency locations, each named <Package>_ROOT after CMake's standard
+# install prefix input, using the package name the dependency would most
+# likely get as a CMake module. Z3Config.cmake and cmake/FindSmtSwitch.cmake
+# let find_package() honor Z3_ROOT and SmtSwitch_ROOT automatically; bitwuzla
+# (pkg-config) and MathSAT (a bare include path) have no module yet, so their
+# roots are applied by hand until one exists.
+cm_Bitwuzla_ROOT="$root_dir/deps/smt-switch/deps/install"
+cm_MathSAT_ROOT="$root_dir/deps/mathsat"
+cm_SmtSwitch_ROOT="$root_dir/deps/smt-switch/local"
+cm_Z3_ROOT="$root_dir/deps/smt-switch/deps/install"
 
 # Build flags
 cm_CMAKE_BUILD_TYPE=Release
@@ -48,10 +59,15 @@ Configures the CMake build environment.
 
 -h, --help              display this message and exit
 
-Directory settings:
+Build and install directories:
 --build-dir=STR         custom build directory (default: $build_dir)
 --prefix=STR            install directory (default: $cm_CMAKE_INSTALL_PREFIX)
---smt-switch-dir=STR    custom smt-switch directory (default: $cm_SMT_SWITCH_DIR)
+
+Dependency locations:
+--bitwuzla-dir=STR      Bitwuzla install prefix (default: $cm_Bitwuzla_ROOT)
+--msat-dir=STR          MathSAT install prefix (default: $cm_MathSAT_ROOT)
+--smt-switch-dir=STR    smt-switch install prefix (default: $cm_SmtSwitch_ROOT)
+--z3-dir=STR            Z3 install prefix (default: $cm_Z3_ROOT)
 
 Build flags:
 --debug                 disable optimizations and include debug symbols (default: $(lowercase "$cm_CMAKE_BUILD_TYPE") build)
@@ -79,13 +95,21 @@ while [[ $# -gt 0 ]]; do
   case $1 in
     -h | --help) usage ;;
 
-    # Directory settings
+    # Build and install directories
     --build-dir) die "missing argument to $1 (see -h)" ;;
     --build-dir=*) build_dir=${1#*=} ;;
     --prefix) die "missing argument to $1 (see -h)" ;;
     --prefix=*) cm_CMAKE_INSTALL_PREFIX=${1#*=} ;;
+
+    # Dependency locations
+    --bitwuzla-dir) die "missing argument to $1 (see -h)" ;;
+    --bitwuzla-dir=*) cm_Bitwuzla_ROOT=${1#*=} ;;
+    --msat-dir) die "missing argument to $1 (see -h)" ;;
+    --msat-dir=*) cm_MathSAT_ROOT=${1#*=} ;;
     --smt-switch-dir) die "missing argument to $1 (see -h)" ;;
-    --smt-switch-dir=*) cm_SMT_SWITCH_DIR=${1#*=} ;;
+    --smt-switch-dir=*) cm_SmtSwitch_ROOT=${1#*=} ;;
+    --z3-dir) die "missing argument to $1 (see -h)" ;;
+    --z3-dir=*) cm_Z3_ROOT=${1#*=} ;;
 
     # Build flags
     --debug) cm_CMAKE_BUILD_TYPE=Debug ;;

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -3,19 +3,38 @@ set -euo pipefail
 
 smt_switch_version=v1.1.4
 
+# Keep the invocation directory to resolve relative path arguments against,
+# since they would otherwise be taken relative to the smt-switch checkout that
+# smt-switch's own configure.sh runs from.
+working_dir=$(pwd)
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
+cd "$root_dir"
+
 usage() {
   cat <<EOF
-Usage: $0 [option] ...
+Usage: $0 [<option> ...]
 
 Sets up the smt-switch API for interfacing with SMT solvers through a C++ API.
 
--h, --help     display this message and exit
---with-btor    include Boolector (default: off)
---with-msat    include MathSAT which is under a custom non-BSD compliant license (default: off)
---with-yices2  include Yices2 which is under a custom non-BSD compliant license (default: off)
---with-z3      include Z3 (default: off)
---cvc5-home    use an already downloaded version of cvc5
---python       build python bindings (default: off)
+Each dependency location below suppresses the download and build of that
+dependency. A --*-dir takes an install prefix, a --*-home a source tree.
+
+-h, --help              display this message and exit
+
+Dependency locations:
+--bitwuzla-dir=STR      use an existing bitwuzla installation
+--btor-home=STR         use an existing Boolector source tree
+--cvc5-home=STR         use an existing cvc5 source tree
+--msat-dir=STR          use an existing MathSAT installation (default: $root_dir/deps/mathsat)
+--yices2-home=STR       use an existing Yices2 source tree
+--z3-dir=STR            use an existing Z3 installation
+
+Optional features / backends (default: off for all):
+--python                build python bindings
+--with-btor             include Boolector
+--with-msat             include MathSAT which is under a custom non-BSD compliant license
+--with-yices2           include Yices2 which is under a custom non-BSD compliant license
+--with-z3               include Z3
 EOF
   exit 0
 }
@@ -25,61 +44,130 @@ die() {
   exit 1
 }
 
-# Navigate to source root
-working_dir=$(pwd)
-cd "$(dirname "${BASH_SOURCE[0]}")"
-cd ..
+abspath() {
+  case $1 in
+    /*) printf '%s\n' "$1" ;;
+    *) printf '%s\n' "$working_dir/$1" ;;
+  esac
+}
 
-# Parse options
-conf_opts=()
+# Parse options. This only records what was requested; the smt-switch options
+# are assembled afterwards so that they do not depend on argument order.
+bitwuzla_dir=
+btor_home=
+cvc5_home=
+msat_dir=
+yices2_home=
+z3_dir=
 with_boolector=false
+with_msat=false
+with_python=false
+with_yices2=false
 with_z3=false
-cvc5_home=default
-incl_solver_str="bitwuzla and cvc5"
-num_of_libs=3 # base, bitwuzla, cvc5
 while (($# > 0)); do
   case $1 in
     -h | --help) usage ;;
-    --with-msat)
-      conf_opts+=(--msat --msat-home="$(pwd)/deps/mathsat")
-      incl_solver_str="mathsat, $incl_solver_str"
-      : $((num_of_libs++))
-      ;;
-    --with-btor)
-      with_boolector=true
-      conf_opts+=(--btor)
-      incl_solver_str="boolector, $incl_solver_str"
-      : $((num_of_libs++))
-      ;;
-    --with-yices2)
-      conf_opts+=(--yices2)
-      incl_solver_str="yices2, $incl_solver_str"
-      : $((num_of_libs++))
-      ;;
-    --with-z3)
-      with_z3=true
-      conf_opts+=(--z3)
-      incl_solver_str="z3, $incl_solver_str"
-      : $((num_of_libs++))
-      ;;
-    --python)
-      conf_opts+=(--python)
-      ;;
+
+    # Dependency locations
+    --bitwuzla-dir) die "missing argument to $1 (see -h)" ;;
+    --bitwuzla-dir=*) bitwuzla_dir=$(abspath "${1#*=}") ;;
+    --btor-home) die "missing argument to $1 (see -h)" ;;
+    --btor-home=*) btor_home=$(abspath "${1#*=}") ;;
     --cvc5-home) die "missing argument to $1 (see -h)" ;;
-    --cvc5-home=*)
-      cvc5_home="${1##*=}"
-      # Check if cvc5_home is an absolute path and
-      # if not, make it absolute.
-      case $cvc5_home in
-        /*) ;;
-        *) cvc5_home="${working_dir}/$cvc5_home" ;;
-      esac
-      conf_opts+=(--cvc5-home="$cvc5_home")
-      ;;
+    --cvc5-home=*) cvc5_home=$(abspath "${1#*=}") ;;
+    --msat-dir) die "missing argument to $1 (see -h)" ;;
+    --msat-dir=*) msat_dir=$(abspath "${1#*=}") ;;
+    --yices2-home) die "missing argument to $1 (see -h)" ;;
+    --yices2-home=*) yices2_home=$(abspath "${1#*=}") ;;
+    --z3-dir) die "missing argument to $1 (see -h)" ;;
+    --z3-dir=*) z3_dir=$(abspath "${1#*=}") ;;
+
+    # Optional features / backends
+    --python) with_python=true ;;
+    --with-btor) with_boolector=true ;;
+    --with-msat) with_msat=true ;;
+    --with-yices2) with_yices2=true ;;
+    --with-z3) with_z3=true ;;
     *) die "unexpected argument: $1" ;;
   esac
   shift
 done
+
+# A solver location on its own would make smt-switch's own configure.sh enable
+# that backend implicitly, which would not match the libraries counted below.
+if [[ -n $btor_home && $with_boolector == false ]]; then
+  die "--btor-home requires --with-btor"
+fi
+if [[ -n $msat_dir && $with_msat == false ]]; then
+  die "--msat-dir requires --with-msat"
+fi
+if [[ -n $yices2_home && $with_yices2 == false ]]; then
+  die "--yices2-home requires --with-yices2"
+fi
+if [[ -n $z3_dir && $with_z3 == false ]]; then
+  die "--z3-dir requires --with-z3"
+fi
+
+# Assemble the options for smt-switch's configure.sh, the solvers to report,
+# and the options the user has to repeat when configuring pono itself.
+conf_opts=()
+pono_opts=()
+solvers=(bitwuzla cvc5)
+num_of_libs=3 # base, bitwuzla, cvc5
+if [[ -n $bitwuzla_dir ]]; then
+  conf_opts+=(--bitwuzla-dir="$bitwuzla_dir")
+  pono_opts+=(--bitwuzla-dir="$bitwuzla_dir")
+fi
+if [[ -n $cvc5_home ]]; then
+  conf_opts+=(--cvc5-home="$cvc5_home")
+fi
+if [[ $with_boolector == true ]]; then
+  conf_opts+=(--btor)
+  pono_opts+=(--with-btor)
+  solvers+=(boolector)
+  : $((num_of_libs++))
+  if [[ -n $btor_home ]]; then
+    conf_opts+=(--btor-home="$btor_home")
+  fi
+fi
+if [[ $with_msat == true ]]; then
+  conf_opts+=(--msat)
+  pono_opts+=(--with-msat)
+  solvers+=(mathsat)
+  : $((num_of_libs++))
+  if [[ -n $msat_dir ]]; then
+    pono_opts+=(--msat-dir="$msat_dir")
+  else
+    # smt-switch looks in its own deps by default; use pono's, which is where
+    # ci-scripts/setup-msat.sh unpacks the download.
+    msat_dir=$root_dir/deps/mathsat
+  fi
+  conf_opts+=(--msat-home="$msat_dir")
+fi
+if [[ $with_yices2 == true ]]; then
+  conf_opts+=(--yices2)
+  pono_opts+=(--with-yices2)
+  solvers+=(yices2)
+  : $((num_of_libs++))
+  if [[ -n $yices2_home ]]; then
+    conf_opts+=(--yices2-home="$yices2_home")
+  fi
+fi
+if [[ $with_z3 == true ]]; then
+  conf_opts+=(--z3)
+  pono_opts+=(--with-z3)
+  solvers+=(z3)
+  : $((num_of_libs++))
+  if [[ -n $z3_dir ]]; then
+    # smt-switch still spells --z3-dir --z3-install-dir.
+    conf_opts+=(--z3-install-dir="$z3_dir")
+    pono_opts+=(--z3-dir="$z3_dir")
+  fi
+fi
+if [[ $with_python == true ]]; then
+  conf_opts+=(--python)
+  pono_opts+=(--python)
+fi
 
 # Download code if needed and check out correct version
 mkdir -p deps
@@ -91,15 +179,17 @@ cd smt-switch
 git checkout -f "$smt_switch_version" ||
   echo "warning: smt-switch folder is not a git repo"
 
-# Build dependencies
-./contrib/setup-bitwuzla.sh
-if [[ $cvc5_home == default ]]; then
+# Build dependencies, skipping the ones we were given a location for
+if [[ -z $bitwuzla_dir ]]; then
+  ./contrib/setup-bitwuzla.sh
+fi
+if [[ -z $cvc5_home ]]; then
   ./contrib/setup-cvc5.sh
 fi
-if [[ $with_boolector == true ]]; then
+if [[ $with_boolector == true && -z $btor_home ]]; then
   ./contrib/setup-boolector.sh
 fi
-if [[ $with_z3 == true ]]; then
+if [[ $with_z3 == true && -z $z3_dir ]]; then
   ./contrib/setup-z3.sh
 fi
 
@@ -120,9 +210,17 @@ cd ..
 # Check that library files are there
 lib_files=(local/lib/libsmt-switch*)
 if ((${#lib_files[@]} == num_of_libs)); then
-  echo "Smt-switch with $incl_solver_str was successfully installed to" \
+  solver_list=$(
+    IFS=,
+    echo "${solvers[*]}"
+  )
+  configure_cmd=./configure.sh
+  if ((${#pono_opts[@]} > 0)); then
+    configure_cmd="$configure_cmd ${pono_opts[*]}"
+  fi
+  echo "Smt-switch with ${solver_list//,/, } was successfully installed to" \
     "$(pwd)/local."
-  echo "You may now build pono with: ./configure.sh && cd build && cmake" \
+  echo "You may now build pono with: $configure_cmd && cd build && cmake" \
     "--build ."
 else
   echo "Building smt-switch failed."


### PR DESCRIPTION
configure.sh's --smt-switch-dir now takes an install prefix that can live anywhere, rather than the root of a built checkout whose local/ and deps/install/ subdirectories had to be reachable. Since deps/install/ is no longer implicitly available, add --bitwuzla-dir and --z3-dir for the two solvers whose object code is not repacked into the smt-switch archives, and --msat-dir for the headers pono includes directly.

The CMake variables are named <Package>_ROOT so find_package() applies them by itself; that lets FindSmtSwitch.cmake drop its HINTS and collapse the Z3 prefer-local-then-system lookup into one call. Defaults live only in configure.sh, so a bare cmake run no longer picks up deps/ silently.