### PR TITLE
build: Add Find modules for the dependencies shipping no CMake config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ pytest tests
 
 Key configure options: `--debug`, `--python`, `--with-msat`, `--with-yices2`, `--with-z3`, `--with-btor`, `--docs`, `--static`.
 
-Dependency locations default to the `deps/` layout the `contrib/` scripts produce, and are overridden with `--smt-switch-dir`, `--bitwuzla-dir`, `--msat-dir`, and `--z3-dir`, each taking an install prefix. These map to `<Package>_ROOT` CMake variables; `configure.sh` is the only place their defaults live.
+Dependency locations default to the `deps/` layout the `contrib/` scripts produce, and are overridden with `--bitwuzla-dir`, `--btor2tools-dir`, `--coreir-dir`, `--ic3ia-dir`, `--msat-dir`, `--smt-switch-dir`, and `--z3-dir`. All take an install prefix except `--ic3ia-dir`, which takes a built source tree since ic3ia has no install step. Each maps to a `<Package>_ROOT` CMake variable consumed by the matching `cmake/Find*.cmake` module; `configure.sh` is the only place their defaults live.
 
 ## Architecture
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,14 +37,8 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 add_definitions(-DPONO_SRC_DIR=${PROJECT_SOURCE_DIR})
 
-if(APPLE)
-  set(SHARED_LIB_EXT "dylib")
-else()
-  set(SHARED_LIB_EXT "so")
-endif()
-
 if(PONO_STATIC_EXEC STREQUAL "YES")
-  if(WITH_COREIR OR WITH_COREIR_EXTERN)
+  if(WITH_COREIR)
     message(
       FATAL_ERROR
       "CoreIR support and a fully static executable are incompatible, since "
@@ -78,7 +72,6 @@ if(WITH_Z3)
 endif()
 
 if(WITH_PROFILING)
-  find_library(GOOGLE_PERF profiler REQUIRED)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWITH_PROFILING")
 endif()
 
@@ -102,15 +95,38 @@ find_package(FLEX 2.6.4 REQUIRED)
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
-# Install prefixes of the dependencies pono locates itself. Declared with an
-# empty default so that configure.sh stays the one place defaults live, and so
-# that leaving a backend disabled does not warn about an unused -D setting.
+# Install prefixes of the dependencies pono locates itself, one per Find
+# module in cmake/. Declared with an empty default so that configure.sh stays
+# the one place defaults live, and so that leaving a backend disabled does not
+# warn about an unused -D setting. IC3IA_ROOT is a source tree rather than an
+# install prefix, since ic3ia has no install step.
 set(Bitwuzla_ROOT "" CACHE PATH "bitwuzla install prefix")
+set(Btor2Tools_ROOT "" CACHE PATH "Btor2Tools install prefix")
+set(CoreIR_ROOT "" CACHE PATH "CoreIR install prefix")
+set(IC3IA_ROOT "" CACHE PATH "ic3ia source tree")
 set(MathSAT_ROOT "" CACHE PATH "MathSAT install prefix")
 set(SmtSwitch_ROOT "" CACHE PATH "smt-switch install prefix")
 set(Z3_ROOT "" CACHE PATH "Z3 install prefix")
 
 find_package(GMPXX REQUIRED)
+find_package(Btor2Tools REQUIRED)
+
+if(WITH_PROFILING)
+  find_package(Gperftools REQUIRED)
+endif()
+
+if(WITH_COREIR)
+  find_package(CoreIR REQUIRED)
+endif()
+
+if(WITH_MSAT OR WITH_MSAT_IC3IA)
+  # pono needs direct access to MathSAT for setting solver options.
+  find_package(MathSAT REQUIRED)
+endif()
+
+if(WITH_MSAT_IC3IA)
+  find_package(IC3IA REQUIRED)
+endif()
 
 set(SmtSwitch_FIND_COMPONENTS bitwuzla cvc5)
 if(WITH_BOOLECTOR)
@@ -126,40 +142,6 @@ if(WITH_Z3)
   list(APPEND SmtSwitch_FIND_COMPONENTS z3)
 endif()
 find_package(SmtSwitch REQUIRED COMPONENTS ${SmtSwitch_FIND_COMPONENTS})
-
-if(WITH_MSAT_IC3IA)
-  if(NOT EXISTS "${PROJECT_SOURCE_DIR}/deps/ic3ia/build/libic3ia.a")
-    message(FATAL_ERROR "Missing ic3ia library -- try running ./contrib/setup-ic3ia.sh")
-  endif()
-endif()
-
-if(WITH_COREIR)
-  if(NOT EXISTS "${PROJECT_SOURCE_DIR}/deps/coreir/local/lib/libcoreir.${SHARED_LIB_EXT}")
-    message(FATAL_ERROR "Missing coreir library. Try running ./contrib/setup-coreir.sh")
-  endif()
-  if(NOT EXISTS "${PROJECT_SOURCE_DIR}/deps/coreir/local/lib/libverilogAST.${SHARED_LIB_EXT}")
-    message(
-      FATAL_ERROR
-      "Missing verilogAST library from coreir. Try running ./contrib/setup-coreir.sh"
-    )
-  endif()
-endif()
-
-list(APPEND CMAKE_PREFIX_PATH "${PROJECT_SOURCE_DIR}/deps/install")
-
-# Check for Btor2Tools
-find_path(Btor2Tools_INCLUDE_DIRS NAMES btor2parser.h)
-if(Btor2Tools_INCLUDE_DIRS)
-  message(STATUS "Found Btor2Tools headers: ${Btor2Tools_INCLUDE_DIRS}")
-else()
-  message(FATAL_ERROR "Missing Btor2Tools headers -- try running ./contrib/setup-btor2tools.sh")
-endif()
-find_library(Btor2Tools_LIBRARIES NAMES btor2parser)
-if(Btor2Tools_LIBRARIES)
-  message(STATUS "Found Btor2Tools library: ${Btor2Tools_LIBRARIES}")
-else()
-  message(FATAL_ERROR "Missing Btor2Tools library -- try running ./contrib/setup-btor2tools.sh")
-endif()
 
 # Generate the SMV parser using Flex/Bison
 bison_target(
@@ -182,7 +164,6 @@ set(
   "${PROJECT_SOURCE_DIR}"
   "${PROJECT_SOURCE_DIR}/contrib/"
   "${PROJECT_SOURCE_DIR}/contrib/optionparser-1.7/src"
-  ${Btor2Tools_INCLUDE_DIRS}
   # generated Bison headers go in build directory
   "${CMAKE_CURRENT_BINARY_DIR}"
 )
@@ -252,28 +233,13 @@ set(
   "${FLEX_SMVScanner_OUTPUTS}"
 )
 
-if(WITH_COREIR OR WITH_COREIR_EXTERN)
+if(WITH_COREIR)
   add_definitions(-DWITH_COREIR)
   set(SOURCES "${SOURCES}" "${PROJECT_SOURCE_DIR}/frontends/coreir_encoder.cpp")
 endif()
 
-if(WITH_MSAT OR WITH_MSAT_IC3IA)
-  # MathSAT has no CMake module yet, so MathSAT_ROOT is checked by hand.
-  if(NOT EXISTS "${MathSAT_ROOT}/include/mathsat.h")
-    message(
-      FATAL_ERROR
-      "Missing MathSAT headers. Set --msat-dir to a MathSAT install prefix "
-      "containing include/mathsat.h (searched: ${MathSAT_ROOT})"
-    )
-  endif()
-  # need direct access to mathsat for setting options
-  set(INCLUDE_DIRS "${INCLUDE_DIRS}" "${MathSAT_ROOT}/include/")
-endif()
-
 if(WITH_MSAT_IC3IA)
   add_definitions(-DWITH_MSAT_IC3IA)
-  # can't include ic3ia directly because some names clash e.g. ic3.h
-  set(INCLUDE_DIRS "${INCLUDE_DIRS}" "${PROJECT_SOURCE_DIR}/deps/")
   set(SOURCES "${SOURCES}" "${PROJECT_SOURCE_DIR}/engines/msat_ic3ia.cpp")
 endif()
 
@@ -309,51 +275,26 @@ if(WITH_Z3)
   target_link_libraries(pono-lib PRIVATE smt-switch-z3)
 endif()
 
-if(WITH_MSAT_IC3IA)
-  target_link_libraries(pono-lib PUBLIC "${PROJECT_SOURCE_DIR}/deps/ic3ia/build/libic3ia.a")
+# MathSAT::mathsat carries only an include directory; pono links MathSAT
+# itself through smt-switch. Both backends need those headers.
+if(WITH_MSAT OR WITH_MSAT_IC3IA)
+  target_link_libraries(pono-lib PUBLIC MathSAT::mathsat)
 endif()
 
-if(WITH_COREIR_EXTERN)
-  if(APPLE)
-    set(COREIR_EXTERN_PREFIX "/usr/local")
-  else()
-    set(COREIR_EXTERN_PREFIX "/usr")
-  endif()
-  add_library(coreir SHARED IMPORTED)
-  set_target_properties(
-    coreir
-    PROPERTIES
-      IMPORTED_LOCATION "${COREIR_EXTERN_PREFIX}/lib/libcoreir${CMAKE_SHARED_LIBRARY_SUFFIX}"
-      INTERFACE_INCLUDE_DIRECTORIES "${COREIR_EXTERN_PREFIX}/include"
-  )
-  add_library(verilogAST SHARED IMPORTED)
-  set_target_properties(
-    verilogAST
-    PROPERTIES
-      IMPORTED_LOCATION "${COREIR_EXTERN_PREFIX}/lib/libverilogAST${CMAKE_SHARED_LIBRARY_SUFFIX}"
-      INTERFACE_INCLUDE_DIRECTORIES "${COREIR_EXTERN_PREFIX}/include"
-  )
-  target_link_libraries(pono-lib PUBLIC coreir verilogAST)
+if(WITH_MSAT_IC3IA)
+  target_link_libraries(pono-lib PUBLIC IC3IA::ic3ia)
 endif()
 
 if(WITH_COREIR)
-  target_include_directories(pono-lib PUBLIC "${PROJECT_SOURCE_DIR}/deps/coreir/local/include")
-  target_link_libraries(
-    pono-lib
-    PUBLIC "${PROJECT_SOURCE_DIR}/deps/coreir/local/lib/libcoreir.${SHARED_LIB_EXT}"
-  )
-  target_link_libraries(
-    pono-lib
-    PUBLIC "${PROJECT_SOURCE_DIR}/deps/coreir/local/lib/libverilogAST.${SHARED_LIB_EXT}"
-  )
+  target_link_libraries(pono-lib PUBLIC CoreIR::coreir CoreIR::verilogAST)
 endif()
 
 target_link_libraries(pono-lib PUBLIC smt-switch)
-target_link_libraries(pono-lib PUBLIC ${Btor2Tools_LIBRARIES})
+target_link_libraries(pono-lib PUBLIC Btor2Tools::btor2parser)
 target_link_libraries(pono-lib PUBLIC GMPXX::gmpxx)
 
-if(GOOGLE_PERF)
-  target_link_libraries(pono-lib PUBLIC ${GOOGLE_PERF})
+if(WITH_PROFILING)
+  target_link_libraries(pono-lib PUBLIC Gperftools::profiler)
 endif()
 
 enable_testing()

--- a/cmake/FindBitwuzla.cmake
+++ b/cmake/FindBitwuzla.cmake
@@ -10,7 +10,7 @@ Hints
 ^^^^^
 
 ``Bitwuzla_ROOT``
-  A bitwuzla install prefix, containing ``lib/pkgconfig/bitwuzla.pc``.
+  A bitwuzla install prefix whose pkgconfig directory holds ``bitwuzla.pc``.
   smt-switch's own ``contrib/setup-bitwuzla.sh`` installs one into
   ``<smt-switch checkout>/deps/install``. If unset, only the system
   pkg-config search path is used.
@@ -31,25 +31,28 @@ Result Variables
 find_package(PkgConfig REQUIRED)
 
 # pkg_check_modules() is not a find_*() command, so it ignores Bitwuzla_ROOT.
-# Extending CMAKE_PREFIX_PATH would reach it, but a find module runs in its
-# caller's directory scope, so that would leak into every later find_*() call
-# there and let this prefix satisfy unrelated lookups. Point pkg-config at the
-# prefix directly instead, and restore the environment afterwards.
-set(_Bitwuzla_saved_pkg_config_path "$ENV{PKG_CONFIG_PATH}")
+# It does consult CMAKE_PREFIX_PATH, and works out which pkgconfig
+# subdirectory a prefix uses on this platform -- lib/<arch>/pkgconfig on
+# Debian derivatives, lib64 or libdata elsewhere, then lib and share. Setting
+# PKG_CONFIG_PATH by hand instead would have to hardcode one of those.
+#
+# Restore the variable afterwards: a find module runs in its caller's
+# directory scope, so leaving it extended would let this prefix satisfy every
+# later find_*() call there, e.g. supplying a Z3 that overrides Z3_ROOT.
+set(_Bitwuzla_saved_prefix_path "${CMAKE_PREFIX_PATH}")
 if(Bitwuzla_ROOT)
-  set(ENV{PKG_CONFIG_PATH} "${Bitwuzla_ROOT}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+  list(PREPEND CMAKE_PREFIX_PATH "${Bitwuzla_ROOT}")
 endif()
 pkg_check_modules(Bitwuzla QUIET bitwuzla)
-set(ENV{PKG_CONFIG_PATH} "${_Bitwuzla_saved_pkg_config_path}")
-unset(_Bitwuzla_saved_pkg_config_path)
+set(CMAKE_PREFIX_PATH "${_Bitwuzla_saved_prefix_path}")
+unset(_Bitwuzla_saved_prefix_path)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   Bitwuzla
   REQUIRED_VARS Bitwuzla_INCLUDE_DIRS Bitwuzla_LDFLAGS
   VERSION_VAR Bitwuzla_VERSION
-  REASON_FAILURE_MESSAGE
-    "No bitwuzla.pc found. Set --bitwuzla-dir to a prefix containing lib/pkgconfig/bitwuzla.pc."
+  REASON_FAILURE_MESSAGE "No bitwuzla.pc found. Set --bitwuzla-dir to a bitwuzla install prefix."
 )
 
 if(Bitwuzla_FOUND AND NOT TARGET Bitwuzla::bitwuzla)

--- a/cmake/FindBitwuzla.cmake
+++ b/cmake/FindBitwuzla.cmake
@@ -1,0 +1,70 @@
+#[=======================================================================[.rst:
+FindBitwuzla
+------------
+
+Finds the Bitwuzla SMT solver (https://github.com/bitwuzla/bitwuzla) via
+pkg-config. Bitwuzla is built with Meson and ships no CMake package config
+files, so this module locates it directly.
+
+Hints
+^^^^^
+
+``Bitwuzla_ROOT``
+  A bitwuzla install prefix, containing ``lib/pkgconfig/bitwuzla.pc``.
+  smt-switch's own ``contrib/setup-bitwuzla.sh`` installs one into
+  ``<smt-switch checkout>/deps/install``. If unset, only the system
+  pkg-config search path is used.
+
+Imported Targets
+^^^^^^^^^^^^^^^^^
+
+``Bitwuzla::bitwuzla``
+  The bitwuzla library and its transitive dependencies, if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^^
+
+``Bitwuzla_FOUND``
+  True if bitwuzla was found.
+#]=======================================================================]
+
+find_package(PkgConfig REQUIRED)
+
+# pkg_check_modules() is not a find_*() command, so it ignores Bitwuzla_ROOT.
+# Extending CMAKE_PREFIX_PATH would reach it, but a find module runs in its
+# caller's directory scope, so that would leak into every later find_*() call
+# there and let this prefix satisfy unrelated lookups. Point pkg-config at the
+# prefix directly instead, and restore the environment afterwards.
+set(_Bitwuzla_saved_pkg_config_path "$ENV{PKG_CONFIG_PATH}")
+if(Bitwuzla_ROOT)
+  set(ENV{PKG_CONFIG_PATH} "${Bitwuzla_ROOT}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+endif()
+pkg_check_modules(Bitwuzla QUIET bitwuzla)
+set(ENV{PKG_CONFIG_PATH} "${_Bitwuzla_saved_pkg_config_path}")
+unset(_Bitwuzla_saved_pkg_config_path)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  Bitwuzla
+  REQUIRED_VARS Bitwuzla_INCLUDE_DIRS Bitwuzla_LDFLAGS
+  VERSION_VAR Bitwuzla_VERSION
+  REASON_FAILURE_MESSAGE
+    "No bitwuzla.pc found. Set --bitwuzla-dir to a prefix containing lib/pkgconfig/bitwuzla.pc."
+)
+
+if(Bitwuzla_FOUND AND NOT TARGET Bitwuzla::bitwuzla)
+  add_library(Bitwuzla::bitwuzla INTERFACE IMPORTED)
+  # Deliberately not IMPORTED_TARGET on pkg_check_modules(): that mode
+  # resolves each transitive library name (e.g. mpfr, a public "Requires:" of
+  # bitwuzla.pc) via find_library(), which prefers .so over .a on Linux. That
+  # breaks fully static executables (PONO_STATIC_EXEC=YES) even when a static
+  # archive is available, since the linker is handed an explicit .so path
+  # instead of a bare -l flag it could resolve itself. Using the raw
+  # pkg-config flags string avoids that.
+  set_target_properties(
+    Bitwuzla::bitwuzla
+    PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${Bitwuzla_INCLUDE_DIRS}"
+      INTERFACE_LINK_LIBRARIES "${Bitwuzla_LDFLAGS}"
+  )
+endif()

--- a/cmake/FindBtor2Tools.cmake
+++ b/cmake/FindBtor2Tools.cmake
@@ -1,0 +1,59 @@
+#[=======================================================================[.rst:
+FindBtor2Tools
+--------------
+
+Finds Btor2Tools (https://github.com/hwmcc/btor2tools), the BTOR2 parser
+library. Btor2Tools ships no CMake package config files, so this module
+locates its header and library directly.
+
+Hints
+^^^^^
+
+``Btor2Tools_ROOT``
+  A Btor2Tools install prefix, i.e. the directory passed to its ``--prefix``.
+  ``contrib/setup-btor2tools.sh`` installs one into ``deps/install``. Being
+  CMake's standard install prefix variable, it needs no explicit ``HINTS``
+  below: ``find_package()`` searches it ahead of ``CMAKE_PREFIX_PATH`` and
+  the system paths.
+
+Imported Targets
+^^^^^^^^^^^^^^^^^
+
+``Btor2Tools::btor2parser``
+  The btor2parser library, if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^^
+
+``Btor2Tools_FOUND``
+  True if btor2parser was found.
+#]=======================================================================]
+
+# These are cached (as find_path()/find_library() results always are), but a
+# cache hit from an earlier configure with a different Btor2Tools_ROOT would
+# otherwise stick around unsearched.
+unset(Btor2Tools_INCLUDE_DIR CACHE)
+find_path(Btor2Tools_INCLUDE_DIR NAMES btor2parser.h)
+
+unset(Btor2Tools_LIBRARY CACHE)
+find_library(Btor2Tools_LIBRARY NAMES btor2parser)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  Btor2Tools
+  REQUIRED_VARS Btor2Tools_LIBRARY Btor2Tools_INCLUDE_DIR
+  REASON_FAILURE_MESSAGE
+    "Try running contrib/setup-btor2tools.sh, or set --btor2tools-dir to an install prefix."
+)
+
+if(Btor2Tools_FOUND AND NOT TARGET Btor2Tools::btor2parser)
+  add_library(Btor2Tools::btor2parser UNKNOWN IMPORTED)
+  set_target_properties(
+    Btor2Tools::btor2parser
+    PROPERTIES
+      IMPORTED_LOCATION "${Btor2Tools_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${Btor2Tools_INCLUDE_DIR}"
+  )
+endif()
+
+mark_as_advanced(Btor2Tools_INCLUDE_DIR Btor2Tools_LIBRARY)

--- a/cmake/FindCoreIR.cmake
+++ b/cmake/FindCoreIR.cmake
@@ -1,0 +1,80 @@
+#[=======================================================================[.rst:
+FindCoreIR
+----------
+
+Finds CoreIR (https://github.com/rdaly525/coreir) and the verilogAST library
+built alongside it. CoreIR ships no CMake package config files, so this module
+locates them directly. Both libraries are required: pono's CoreIR frontend
+links against each.
+
+CoreIR is only available as a shared library, so it is incompatible with
+``PONO_STATIC_EXEC=YES``.
+
+Hints
+^^^^^
+
+``CoreIR_ROOT``
+  A CoreIR install prefix. ``contrib/setup-coreir.sh`` installs one into
+  ``deps/coreir/local``; a system-wide installation is typically ``/usr`` or
+  ``/usr/local``. Being CMake's standard install prefix variable, it needs no
+  explicit ``HINTS`` below: ``find_package()`` searches it ahead of
+  ``CMAKE_PREFIX_PATH`` and the system paths.
+
+Imported Targets
+^^^^^^^^^^^^^^^^^
+
+``CoreIR::coreir``
+  The CoreIR library, if found.
+
+``CoreIR::verilogAST``
+  The verilogAST library, if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^^
+
+``CoreIR_FOUND``
+  True if both libraries and the headers were found.
+#]=======================================================================]
+
+# These are cached (as find_path()/find_library() results always are), but a
+# cache hit from an earlier configure with a different CoreIR_ROOT would
+# otherwise stick around unsearched.
+unset(CoreIR_INCLUDE_DIR CACHE)
+find_path(CoreIR_INCLUDE_DIR NAMES coreir.h)
+
+unset(CoreIR_LIBRARY CACHE)
+find_library(CoreIR_LIBRARY NAMES coreir)
+
+unset(CoreIR_verilogAST_LIBRARY CACHE)
+find_library(CoreIR_verilogAST_LIBRARY NAMES verilogAST)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  CoreIR
+  REQUIRED_VARS CoreIR_LIBRARY CoreIR_verilogAST_LIBRARY CoreIR_INCLUDE_DIR
+  REASON_FAILURE_MESSAGE
+    "Try running contrib/setup-coreir.sh, or set --coreir-dir to an install prefix."
+)
+
+if(CoreIR_FOUND)
+  if(NOT TARGET CoreIR::coreir)
+    add_library(CoreIR::coreir UNKNOWN IMPORTED)
+    set_target_properties(
+      CoreIR::coreir
+      PROPERTIES
+        IMPORTED_LOCATION "${CoreIR_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${CoreIR_INCLUDE_DIR}"
+    )
+  endif()
+  if(NOT TARGET CoreIR::verilogAST)
+    add_library(CoreIR::verilogAST UNKNOWN IMPORTED)
+    set_target_properties(
+      CoreIR::verilogAST
+      PROPERTIES
+        IMPORTED_LOCATION "${CoreIR_verilogAST_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${CoreIR_INCLUDE_DIR}"
+    )
+  endif()
+endif()
+
+mark_as_advanced(CoreIR_INCLUDE_DIR CoreIR_LIBRARY CoreIR_verilogAST_LIBRARY)

--- a/cmake/FindGperftools.cmake
+++ b/cmake/FindGperftools.cmake
@@ -1,0 +1,42 @@
+#[=======================================================================[.rst:
+FindGperftools
+--------------
+
+Finds the CPU profiler from gperftools (https://github.com/gperftools/gperftools)
+via pkg-config. gperftools ships no CMake package config files, so this module
+locates it directly.
+
+Imported Targets
+^^^^^^^^^^^^^^^^^
+
+``Gperftools::profiler``
+  The libprofiler library, if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^^
+
+``Gperftools_FOUND``
+  True if libprofiler was found.
+#]=======================================================================]
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(Gperftools QUIET libprofiler)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  Gperftools
+  REQUIRED_VARS Gperftools_LDFLAGS
+  VERSION_VAR Gperftools_VERSION
+  REASON_FAILURE_MESSAGE
+    "No libprofiler.pc found. Install gperftools to build with --with-profiling."
+)
+
+if(Gperftools_FOUND AND NOT TARGET Gperftools::profiler)
+  add_library(Gperftools::profiler INTERFACE IMPORTED)
+  set_target_properties(
+    Gperftools::profiler
+    PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${Gperftools_INCLUDE_DIRS}"
+      INTERFACE_LINK_LIBRARIES "${Gperftools_LDFLAGS}"
+  )
+endif()

--- a/cmake/FindIC3IA.cmake
+++ b/cmake/FindIC3IA.cmake
@@ -1,0 +1,66 @@
+#[=======================================================================[.rst:
+FindIC3IA
+---------
+
+Finds ic3ia (https://es-static.fbk.eu/people/griggio/ic3ia/index.html), an
+implementation of IC3 modulo theories with implicit predicate abstraction.
+
+ic3ia has no install step -- ``contrib/setup-ic3ia.sh`` builds it in place --
+so this module is the one here that cannot rely on ``IC3IA_ROOT`` alone:
+headers stay in the source tree and the library in its build directory,
+neither of which is a location ``find_package()`` searches under a prefix.
+Both lookups therefore need explicit ``HINTS``.
+
+Hints
+^^^^^
+
+``IC3IA_ROOT``
+  An ic3ia source tree that has been built, i.e. one containing ``ic3.h`` and
+  ``build/libic3ia.a``. ``contrib/setup-ic3ia.sh`` produces one in
+  ``deps/ic3ia``.
+
+Imported Targets
+^^^^^^^^^^^^^^^^^
+
+``IC3IA::ic3ia``
+  The ic3ia library, if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^^
+
+``IC3IA_FOUND``
+  True if the ic3ia library and headers were found.
+#]=======================================================================]
+
+# These are cached (as find_path()/find_library() results always are), but a
+# cache hit from an earlier configure with a different IC3IA_ROOT would
+# otherwise stick around unsearched.
+#
+# pono includes ic3ia's headers as e.g. "ic3ia/ic3.h" -- it cannot include
+# them directly, because some names clash with pono's own (ic3.h). So the
+# include directory is the *parent* of the ic3ia tree.
+unset(IC3IA_INCLUDE_DIR CACHE)
+find_path(IC3IA_INCLUDE_DIR NAMES ic3ia/ic3.h HINTS "${IC3IA_ROOT}/..")
+
+unset(IC3IA_LIBRARY CACHE)
+find_library(IC3IA_LIBRARY NAMES ic3ia HINTS "${IC3IA_ROOT}/build")
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  IC3IA
+  REQUIRED_VARS IC3IA_LIBRARY IC3IA_INCLUDE_DIR
+  REASON_FAILURE_MESSAGE
+    "Try running contrib/setup-ic3ia.sh, or set --ic3ia-dir to a built ic3ia source tree."
+)
+
+if(IC3IA_FOUND AND NOT TARGET IC3IA::ic3ia)
+  add_library(IC3IA::ic3ia UNKNOWN IMPORTED)
+  set_target_properties(
+    IC3IA::ic3ia
+    PROPERTIES
+      IMPORTED_LOCATION "${IC3IA_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${IC3IA_INCLUDE_DIR}"
+  )
+endif()
+
+mark_as_advanced(IC3IA_INCLUDE_DIR IC3IA_LIBRARY)

--- a/cmake/FindMathSAT.cmake
+++ b/cmake/FindMathSAT.cmake
@@ -1,0 +1,60 @@
+#[=======================================================================[.rst:
+FindMathSAT
+-----------
+
+Finds the MathSAT 5 SMT solver's headers (https://mathsat.fbk.eu). MathSAT is
+distributed as a prebuilt archive and ships no CMake package config files, so
+this module locates it directly.
+
+Only the headers are located, not ``libmathsat``. pono needs direct access to
+MathSAT's C API to set solver options, but links MathSAT through smt-switch:
+a static smt-switch build repacks MathSAT's objects into
+``libsmt-switch-msat.a``, so also linking the standalone archive would risk
+duplicate definitions.
+
+Hints
+^^^^^
+
+``MathSAT_ROOT``
+  A MathSAT install prefix -- the unpacked release archive, which contains
+  ``include`` and ``lib`` directories. ``ci-scripts/setup-msat.sh`` unpacks
+  one into ``deps/mathsat``. Being CMake's standard install prefix variable,
+  it needs no explicit ``HINTS`` below: ``find_package()`` searches it ahead
+  of ``CMAKE_PREFIX_PATH`` and the system paths.
+
+Imported Targets
+^^^^^^^^^^^^^^^^^
+
+``MathSAT::mathsat``
+  Interface target carrying MathSAT's include directory, if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^^
+
+``MathSAT_FOUND``
+  True if the MathSAT headers were found.
+#]=======================================================================]
+
+# Cached (as find_path() results always are), but a cache hit from an earlier
+# configure with a different MathSAT_ROOT would otherwise stick around
+# unsearched.
+unset(MathSAT_INCLUDE_DIR CACHE)
+find_path(MathSAT_INCLUDE_DIR NAMES mathsat.h)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  MathSAT
+  REQUIRED_VARS MathSAT_INCLUDE_DIR
+  REASON_FAILURE_MESSAGE
+    "Try running ci-scripts/setup-msat.sh, or set --msat-dir to an install prefix."
+)
+
+if(MathSAT_FOUND AND NOT TARGET MathSAT::mathsat)
+  add_library(MathSAT::mathsat INTERFACE IMPORTED)
+  set_target_properties(
+    MathSAT::mathsat
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${MathSAT_INCLUDE_DIR}"
+  )
+endif()
+
+mark_as_advanced(MathSAT_INCLUDE_DIR)

--- a/cmake/FindSmtSwitch.cmake
+++ b/cmake/FindSmtSwitch.cmake
@@ -26,12 +26,10 @@ Hints
   ``find_package()`` searches it ahead of ``CMAKE_PREFIX_PATH`` and the
   system paths.
 
-``Bitwuzla_ROOT``
-  A bitwuzla install prefix, containing ``lib/pkgconfig/bitwuzla.pc``.
-  smt-switch's own ``contrib/setup-bitwuzla.sh`` installs one into
-  ``<smt-switch checkout>/deps/install``. Only consulted when the
-  ``bitwuzla`` component is requested, and applied by hand rather than by
-  ``find_package()``, since bitwuzla is located with pkg-config.
+Requesting the ``bitwuzla`` component additionally requires a bitwuzla
+installation, since smt-switch's own bitwuzla backend links against it
+directly and is not repacked into ``libsmt-switch-bitwuzla.a``. It is located
+by ``FindBitwuzla``; set ``Bitwuzla_ROOT`` to select one.
 
 Requesting the ``z3`` component additionally requires a Z3 installation
 discoverable via its own CMake package config, since smt-switch's own Z3
@@ -129,36 +127,11 @@ if(SmtSwitch_FOUND AND NOT TARGET smt-switch)
       smt-switch-bitwuzla
       PROPERTIES IMPORTED_LOCATION "${SmtSwitch_bitwuzla_LIBRARY}"
     )
-    find_package(PkgConfig REQUIRED)
-    # pkg_check_modules() is not a find_*() command, so it does not consult
-    # Bitwuzla_ROOT on its own; it does search CMAKE_PREFIX_PATH.
-    if(Bitwuzla_ROOT)
-      list(APPEND CMAKE_PREFIX_PATH "${Bitwuzla_ROOT}")
-    endif()
-    # Deliberately not IMPORTED_TARGET: that mode resolves each transitive
-    # library name (e.g. mpfr, a public "Requires:" of bitwuzla.pc) via
-    # find_library(), which prefers .so over .a on Linux. That breaks fully
-    # static executables (PONO_STATIC_EXEC=YES) even when a static archive
-    # is available, since the linker is handed an explicit .so path instead
-    # of a bare -l flag it could resolve itself. Using the raw pkg-config
-    # flags string avoids that.
-    pkg_check_modules(SMTSWITCH_BITWUZLA bitwuzla)
-    if(NOT SMTSWITCH_BITWUZLA_FOUND)
-      message(
-        FATAL_ERROR
-        "Could not find bitwuzla.pc. Set --bitwuzla-dir to a bitwuzla install "
-        "prefix containing lib/pkgconfig/bitwuzla.pc (searched: ${Bitwuzla_ROOT})"
-      )
-    endif()
+    find_package(Bitwuzla REQUIRED)
     set_property(
       TARGET smt-switch-bitwuzla
       APPEND
-      PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${SMTSWITCH_BITWUZLA_INCLUDE_DIRS}
-    )
-    set_property(
-      TARGET smt-switch-bitwuzla
-      APPEND
-      PROPERTY INTERFACE_LINK_LIBRARIES smt-switch "${SMTSWITCH_BITWUZLA_LDFLAGS}"
+      PROPERTY INTERFACE_LINK_LIBRARIES smt-switch Bitwuzla::bitwuzla
     )
   endif()
 

--- a/configure.sh
+++ b/configure.sh
@@ -25,6 +25,10 @@ cm_CMAKE_INSTALL_PREFIX=/usr/local
 # (pkg-config) and MathSAT (a bare include path) have no module yet, so their
 # roots are applied by hand until one exists.
 cm_Bitwuzla_ROOT="$root_dir/deps/smt-switch/deps/install"
+cm_Btor2Tools_ROOT="$root_dir/deps/install"
+cm_CoreIR_ROOT="$root_dir/deps/coreir/local"
+# ic3ia has no install step, so this is a built source tree, not a prefix.
+cm_IC3IA_ROOT="$root_dir/deps/ic3ia"
 cm_MathSAT_ROOT="$root_dir/deps/mathsat"
 cm_SmtSwitch_ROOT="$root_dir/deps/smt-switch/local"
 cm_Z3_ROOT="$root_dir/deps/smt-switch/deps/install"
@@ -40,7 +44,6 @@ cm_BUILD_PYTHON_BINDINGS=OFF
 cm_SYSTEM_GTEST=ON
 cm_WITH_BOOLECTOR=OFF
 cm_WITH_COREIR=OFF
-cm_WITH_COREIR_EXTERN=OFF
 cm_WITH_MSAT=OFF
 cm_WITH_MSAT_IC3IA=OFF
 cm_WITH_PROFILING=OFF
@@ -65,6 +68,9 @@ Build and install directories:
 
 Dependency locations:
 --bitwuzla-dir=STR      Bitwuzla install prefix (default: $cm_Bitwuzla_ROOT)
+--btor2tools-dir=STR    Btor2Tools install prefix (default: $cm_Btor2Tools_ROOT)
+--coreir-dir=STR        CoreIR install prefix (default: $cm_CoreIR_ROOT)
+--ic3ia-dir=STR         built ic3ia source tree (default: $cm_IC3IA_ROOT)
 --msat-dir=STR          MathSAT install prefix (default: $cm_MathSAT_ROOT)
 --smt-switch-dir=STR    smt-switch install prefix (default: $cm_SmtSwitch_ROOT)
 --z3-dir=STR            Z3 install prefix (default: $cm_Z3_ROOT)
@@ -80,7 +86,6 @@ Optional features / backends (default: false/off for all):
 --python                compile with Python bindings
 --with-btor             build with Boolector
 --with-coreir           build the CoreIR frontend
---with-coreir-extern    build the CoreIR frontend using an installation in /usr/local/lib
 --with-msat             build with MathSAT which has a custom non-BSD compliant license
 --with-msat-ic3ia       build with the open-source IC3IA implementation as a backend
 --with-profiling        build with gperftools for profiling
@@ -104,6 +109,12 @@ while [[ $# -gt 0 ]]; do
     # Dependency locations
     --bitwuzla-dir) die "missing argument to $1 (see -h)" ;;
     --bitwuzla-dir=*) cm_Bitwuzla_ROOT=${1#*=} ;;
+    --btor2tools-dir) die "missing argument to $1 (see -h)" ;;
+    --btor2tools-dir=*) cm_Btor2Tools_ROOT=${1#*=} ;;
+    --coreir-dir) die "missing argument to $1 (see -h)" ;;
+    --coreir-dir=*) cm_CoreIR_ROOT=${1#*=} ;;
+    --ic3ia-dir) die "missing argument to $1 (see -h)" ;;
+    --ic3ia-dir=*) cm_IC3IA_ROOT=${1#*=} ;;
     --msat-dir) die "missing argument to $1 (see -h)" ;;
     --msat-dir=*) cm_MathSAT_ROOT=${1#*=} ;;
     --smt-switch-dir) die "missing argument to $1 (see -h)" ;;
@@ -122,7 +133,9 @@ while [[ $# -gt 0 ]]; do
     --python) cm_BUILD_PYTHON_BINDINGS=ON ;;
     --with-btor) cm_WITH_BOOLECTOR=ON ;;
     --with-coreir) cm_WITH_COREIR=ON ;;
-    --with-coreir-extern) cm_WITH_COREIR_EXTERN=ON ;;
+    --with-coreir-extern*)
+      die "$1 was replaced by --with-coreir --coreir-dir=STR (see -h)"
+      ;;
     --with-msat) cm_WITH_MSAT=ON ;;
     --with-msat-ic3ia) cm_WITH_MSAT_IC3IA=ON ;;
     --with-profiling) cm_WITH_PROFILING=ON ;;

--- a/python/pono/CMakeLists.txt
+++ b/python/pono/CMakeLists.txt
@@ -3,7 +3,7 @@ configure_file(pono_imp.pxd pono_imp.pxd COPYONLY)
 
 # Set Cython compilation flags.
 set(CYTHON_FLAGS -3 --cplus --module-name pono._pono_impl)
-if(WITH_COREIR OR WITH_COREIR_EXTERN)
+if(WITH_COREIR)
   list(APPEND CYTHON_FLAGS --compile-time-env WITH_COREIR=ON)
 else()
   list(APPEND CYTHON_FLAGS --compile-time-env WITH_COREIR=OFF)


### PR DESCRIPTION
Btor2tools, CoreIR, gperftools, ic3ia, MathSAT, and Bitwuzla were each located
differently: bare find_path/find_library pairs, raw pkg_check_modules inlined
into FindSmtSwitch's bitwuzla component, or hardcoded deps/ paths passed
straight to target_link_libraries. Give each one a module in cmake/ with a
<Package>_ROOT hint and a --*-dir flag, so they can be relocated and so their
diagnostics come from find_package_handle_standard_args.

Locating Bitwuzla no longer widens CMAKE_PREFIX_PATH in the caller's scope.
That leaked into later lookups: the Bitwuzla prefix could satisfy
find_package(Z3) in place of an explicit --z3-dir, and decided whether
Btor2Tools resolved from pono's deps/install or smt-switch's. FindBitwuzla now
extends it only around its own pkg_check_modules call, which is also what
picks the platform's pkgconfig subdirectory (lib/<arch> on Debian).

--with-coreir-extern is retired, since --with-coreir --coreir-dir=/usr now
covers it; passing it reports the replacement. Profiling links libprofiler
under WITH_PROFILING rather than under a cached find_library result, which
previously kept linking it after the flag was dropped.