### PR TITLE
build: Rework the version plumbing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ __pycache__
 # Generated files
 .gdb_history
 compile_commands.json
+# INCLUDE_DIRS lists the source tree ahead of the build directory, so a stale
+# in-source copy of this would silently win over the generated one.
+options/version.h
 
 # IDE settings
 .vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,21 @@
 cmake_minimum_required(VERSION 3.18...4.0)
 
-project(pono)
+project(pono VERSION 2.1.0)
 
-set(PONO_MAJOR 0) # Major component of Pono version
-set(PONO_MINOR 1) # Minor component of Pono version
-set(PONO_RELEASE 1) # Release component of Pono version
+# Pre-release/dev suffix appended to PROJECT_VERSION. project(VERSION) accepts
+# only numeric components, so prerelease markers live here. Spelled in PEP 440
+# form ("b1", "rc1", ".dev0") so that the C++ and Python versions stay a single
+# string. Empty for final releases.
+set(PONO_VERSION_SUFFIX ".dev0")
+
+# The declared version, and the single source of truth for every version
+# pono reports: --version, the wheel, and pono.__version__.
+set(PONO_RELEASE_VERSION "${PROJECT_VERSION}${PONO_VERSION_SUFFIX}")
 
 # Generate compilation database compile_commands.json
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-# Retrieve the current version via Git
-execute_process(
-  COMMAND git describe --always --dirty
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  RESULT_VARIABLE GIT_DESCRIBE_STATUS
-  OUTPUT_VARIABLE PONO_VERSION
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-if(GIT_DESCRIBE_STATUS AND NOT GIT_DESCRIBE_STATUS EQUAL 0)
-  set(PONO_VERSION "v${PONO_MAJOR}.${PONO_MINOR}.${PONO_RELEASE}")
-endif()
+include("${PROJECT_SOURCE_DIR}/cmake/PonoVersion.cmake")
 
 # handle different versions of CMake
 if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0 AND NOT APPLE)
@@ -191,7 +187,7 @@ set(
   INCLUDE_DIRS
   "${PROJECT_SOURCE_DIR}"
   "${PROJECT_SOURCE_DIR}/contrib/optionparser-1.7/src"
-  # generated Bison headers go in build directory
+  # generated headers go in build directory
   "${CMAKE_CURRENT_BINARY_DIR}"
 )
 
@@ -272,7 +268,11 @@ endif()
 
 add_library(pono-lib "${PONO_LIB_TYPE}" ${SOURCES})
 set_target_properties(pono-lib PROPERTIES OUTPUT_NAME pono)
-target_compile_definitions(pono-lib PRIVATE "-DPONO_VERSION=\"${PONO_VERSION}\"")
+
+# A target-level edge, so that both the Ninja and Makefile generators finish
+# writing version.h before starting any pono-lib object. Everything else links
+# pono-lib and inherits the ordering.
+add_dependencies(pono-lib pono-version-header)
 
 target_include_directories(pono-lib PUBLIC ${INCLUDE_DIRS})
 
@@ -336,6 +336,10 @@ add_subdirectory(tests EXCLUDE_FROM_ALL)
 
 add_executable(pono-bin "${PROJECT_SOURCE_DIR}/pono.cpp")
 set_target_properties(pono-bin PROPERTIES OUTPUT_NAME pono)
+
+# test_version runs the executable itself, so `check` has to build it. Wired
+# up here because pono-bin does not exist yet while tests/ is processed.
+add_dependencies(check pono-bin)
 
 target_include_directories(
   pono-bin

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,102 @@
+# Releasing Pono
+
+Every version Pono reports derives from two variables at the top of the
+top-level `CMakeLists.txt`:
+
+- `project(pono VERSION <major>.<minor>.<patch>)`, the declared release version.
+- `PONO_VERSION_SUFFIX`, a PEP 440 pre-release or development marker appended to
+  it, empty for a final release.
+
+Together they form `PONO_RELEASE_VERSION`, which feeds `pono --version`, the
+Python wheel's version, and `pono.__version__`. No other file records the
+version, so there is nothing else to edit.
+
+`pono --version` also reports the commit the binary was built from, re-derived
+on every build:
+
+```
+2.1.0.dev0 (v2.0.0-63-g1a2b3c4)   built from a git checkout
+2.1.0.dev0 (1a2b3c4)              shallow checkout with no tags, as in CI
+2.1.0.dev0                        release tarball, or no git available
+```
+
+The declared version always comes first, so anything parsing that output should
+read the first whitespace-delimited token.
+
+## Cutting a release
+
+1. Clear the suffix in `CMakeLists.txt`:
+
+   ```cmake
+   set(PONO_VERSION_SUFFIX "")
+   ```
+
+   Check that `project(pono VERSION ...)` already names the version you intend
+   to release. It is raised at the start of each development cycle, not here.
+
+2. Commit, then confirm the version reads as expected. Editing `CMakeLists.txt`
+   re-triggers configure on its own:
+
+   ```
+   cmake --build build --target pono-bin && ./build/pono --version
+   ```
+
+3. Tag the release commit. The tag must start with `v`:
+
+   ```
+   git tag -a v2.1.0 -m 'Pono 2.1.0'
+   ```
+
+   Prefer an annotated tag (`-a`). A lightweight tag is a plain ref that can be
+   force-moved without leaving a tagger, date, or message behind, so nothing
+   would record that a release tag had changed.
+
+4. Push the commit and the tag.
+
+5. Open the next development cycle in a follow-up commit: raise
+   `project(pono VERSION ...)` and set `PONO_VERSION_SUFFIX` back to `".dev0"`,
+   so mainline reports e.g. `2.2.0.dev0`.
+
+## Why the tag needs the `v` prefix
+
+The provenance suffix comes from
+
+```
+git describe --tags --always --dirty --match "v[0-9]*"
+```
+
+A tag without the `v` does not match, and `--always` then falls back to a bare
+commit hash. Nothing fails: `pono --version` just quietly stops naming the
+release a build descends from. Note the asymmetry is deliberate, in that the
+tag carries the `v` and the declared version does not.
+
+`--match` also stops a competition snapshot tag (`hwmcc*`) from winning on
+distance, and `--tags` is what makes lightweight tags visible at all.
+
+## Pre-releases
+
+Set the suffix to a PEP 440 marker and tag to match:
+
+| `PONO_VERSION_SUFFIX` | reported version | tag |
+| --- | --- | --- |
+| `".dev0"` | `2.1.0.dev0` | untagged mainline |
+| `"b1"` | `2.1.0b1` | `v2.1.0b1` |
+| `"rc1"` | `2.1.0rc1` | `v2.1.0rc1` |
+| `""` | `2.1.0` | `v2.1.0` |
+
+PEP 440 orders these `2.1.0.dev0` < `2.1.0b1` < `2.1.0rc1` < `2.1.0`.
+
+Keep the suffix in PEP 440 spelling rather than something like `-beta.1`. The
+same string becomes both the C++ and the Python version, and a version that
+PEP 440 rejects breaks the wheel build. `project(VERSION)` accepts only numeric
+components, which is why the marker lives in a separate variable.
+
+## What a release does not do
+
+- **Publish to PyPI.** `.github/workflows/wheels.yml` triggers on any tag push
+  but is currently disabled, and the `contrib/wheels/` scripts behind it are
+  unmaintained: they target Python 3.5 to 3.8 and carry their own hardcoded
+  version. Publishing a release to PyPI needs that path replaced first.
+- **Tag a container image.** `.github/workflows/docker.yml` publishes only
+  `ghcr.io/stanford-centaur/pono:latest`, with no per-version tag.
+- **Update a changelog.** There is none.

--- a/cmake/PonoVersion.cmake
+++ b/cmake/PonoVersion.cmake
@@ -1,0 +1,39 @@
+# Sets up generation of options/version.h, which carries the declared release
+# version plus the commit provenance of the build. Expects
+# PONO_RELEASE_VERSION to be set already.
+
+find_package(Git QUIET)
+
+# Private to pono-lib: the install rules copy *.h out of the source tree, so
+# this generated header is deliberately not installed, and
+# options/options.cpp is its only includer.
+set(PONO_VERSION_HEADER "${CMAKE_CURRENT_BINARY_DIR}/options/version.h")
+
+set(
+  PONO_VERSION_GEN_COMMAND
+  "${CMAKE_COMMAND}"
+  "-DGIT_EXECUTABLE=${GIT_EXECUTABLE}"
+  "-DPONO_SOURCE_DIR=${PROJECT_SOURCE_DIR}"
+  "-DPONO_RELEASE_VERSION=${PONO_RELEASE_VERSION}"
+  "-DINPUT=${PROJECT_SOURCE_DIR}/options/version.h.in"
+  "-DOUTPUT=${PONO_VERSION_HEADER}"
+  -P
+  "${PROJECT_SOURCE_DIR}/cmake/WritePonoVersionHeader.cmake"
+)
+
+# Seed the header so that clangd and other compile_commands.json consumers
+# find it before the first build.
+execute_process(COMMAND ${PONO_VERSION_GEN_COMMAND})
+
+# Re-derived on every build so the provenance cannot go stale between
+# configures. This has to be an always-run target rather than a custom command
+# with DEPENDS: --dirty flips when a tracked source is edited, which touches
+# no file a command could depend on. configure_file rewrites the header only
+# when the version actually changed, so the rebuild stays proportionate.
+add_custom_target(
+  pono-version-header
+  BYPRODUCTS "${PONO_VERSION_HEADER}"
+  COMMAND ${PONO_VERSION_GEN_COMMAND}
+  COMMENT "Checking pono build provenance"
+  VERBATIM
+)

--- a/cmake/WritePonoVersionHeader.cmake
+++ b/cmake/WritePonoVersionHeader.cmake
@@ -1,0 +1,43 @@
+# Generates the pono version header. Run via `cmake -P`, both once at
+# configure time to seed the header and again on every build, so that the
+# commit provenance below is re-derived instead of snapshotted.
+#
+# Inputs, all passed with -D:
+#
+# GIT_EXECUTABLE       git binary, or empty when git is unavailable
+# PONO_SOURCE_DIR      pono source tree to describe
+# PONO_RELEASE_VERSION declared version, reported with or without git
+# INPUT                header template to configure
+# OUTPUT               header to generate
+
+set(PONO_GIT_DESCRIBE "")
+
+if(GIT_EXECUTABLE)
+  # --tags is load-bearing: release tags here are lightweight, and plain
+  # `git describe` considers only annotated tags. --match confines the search
+  # to release tags, so a competition snapshot tag (hwmcc*) landing on
+  # mainline cannot win on distance. -C resolves the gitfile pointer that a
+  # linked worktree has in place of a .git directory.
+  execute_process(
+    COMMAND
+      "${GIT_EXECUTABLE}" -C "${PONO_SOURCE_DIR}" describe --tags --always --dirty --match
+      "v[0-9]*"
+    RESULT_VARIABLE GIT_DESCRIBE_STATUS
+    OUTPUT_VARIABLE PONO_GIT_DESCRIBE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+  )
+  # Anything short of success (no git history, as in a tarball or a Docker
+  # build context) leaves the version without a provenance suffix.
+  if(NOT GIT_DESCRIBE_STATUS EQUAL 0)
+    set(PONO_GIT_DESCRIBE "")
+  endif()
+endif()
+
+if(PONO_GIT_DESCRIBE)
+  set(PONO_VERSION "${PONO_RELEASE_VERSION} (${PONO_GIT_DESCRIBE})")
+else()
+  set(PONO_VERSION "${PONO_RELEASE_VERSION}")
+endif()
+
+configure_file("${INPUT}" "${OUTPUT}" @ONLY)

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -23,11 +23,8 @@
 #include <vector>
 
 #include "optionparser.h"
+#include "options/version.h"
 #include "utils/exceptions.h"
-
-#ifndef PONO_VERSION
-#define PONO_VERSION "unknown"
-#endif
 
 using namespace std;
 
@@ -832,7 +829,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
   }
 
   if (options[VERSION]) {
-    cout << PONO_VERSION << endl;
+    cout << version << endl;
     return ERROR;
   }
 

--- a/options/version.h.in
+++ b/options/version.h.in
@@ -1,0 +1,23 @@
+/*!
+ * \file version.h.in
+ * \brief The pono version reported by `pono --version`.
+ * \author Áron Ricardo Perez-Lopez
+ * \date 2026
+ * \copyright See the LICENSE file in the top-level source directory.
+ *
+ * Template for options/version.h in the build tree. The declared release
+ * version comes from project(VERSION) and PONO_VERSION_SUFFIX, while the
+ * commit provenance in parentheses is re-derived by
+ * cmake/WritePonoVersionHeader.cmake on every build.
+ */
+
+#pragma once
+
+namespace pono {
+
+/// Version reported by `pono --version`: the declared release version,
+/// followed by this build's commit provenance in parentheses where git can
+/// supply it. Machine consumers read the first whitespace-delimited token.
+inline constexpr const char * version = "@PONO_VERSION@";
+
+}  // namespace pono

--- a/python/pono/__init__.py.in
+++ b/python/pono/__init__.py.in
@@ -1,3 +1,3 @@
 from ._pono_impl import *
 
-__version__ = "@PONO_MAJOR@.@PONO_MINOR@.@PONO_RELEASE@"
+__version__ = "@PONO_RELEASE_VERSION@"

--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pono"
-version = "@PONO_MAJOR@.@PONO_MINOR@.@PONO_RELEASE@"
+version = "@PONO_RELEASE_VERSION@"
 description = "Python bindings for the model checker Pono"
 readme = {text = "Python bindings for the model checker Pono", content-type = "text/plain"}
 license = "BSD-3-Clause"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -93,4 +93,16 @@ if(WITH_MSAT_IC3IA)
   pono_add_test(test_msat_ic3ia)
 endif()
 
+# Smoke-test the version plumbing. The dots are escaped because the property
+# below is a regex, not a literal.
+string(REPLACE "." "\\." PONO_RELEASE_VERSION_REGEX "${PONO_RELEASE_VERSION}")
+add_test(NAME test_version COMMAND pono-bin --version)
+# Anchoring on the declared version pins the contract that it comes first.
+# The property is also required rather than stylistic: it replaces ctest's
+# return-code check, and `pono --version` exits 2.
+set_tests_properties(
+  test_version
+  PROPERTIES PASS_REGULAR_EXPRESSION "^${PONO_RELEASE_VERSION_REGEX}"
+)
+
 add_subdirectory(encoders)


### PR DESCRIPTION
The version was a configure-time snapshot of `git describe`, so it went stale until someone re-ran cmake. Separately, the release version was declared in four places that had drifted apart: PONO_MAJOR/MINOR/RELEASE said 0.1.1 while the newest release tag was v2.0.0, and `pono --version` and `pono.__version__` reported different versions from the same tree.

Split the two concerns. The declared version, project(VERSION) plus a PEP 440 suffix, becomes the single source of truth behind --version, the wheel and pono.__version__. Commit provenance stays a best-effort addition, re-derived on every build:

    2.1.0.dev0 (v2.0.0-63-g1a2b3c4)   git available
    2.1.0.dev0 (1a2b3c4)              shallow checkout, no tags
    2.1.0.dev0                        tarball, or no git at all

Machine consumers read the first whitespace-delimited token, and no build reports the hardcoded v0.1.1 fallback any more.

Two constraints shaped this: project(VERSION) rejects non-numeric components, so the prerelease marker needs its own variable; and a `git describe` string is not valid PEP 440, so only the declared version may reach pyproject.toml.

The header is generated copy-if-different, so an unchanged version rebuilds nothing and a changed one costs the single translation unit that reads it. The compile definition it replaces was attached to pono-lib, so moving HEAD invalidated all ~63 of its objects.

RELEASING.md documents the procedure, whose absence is what let the four declarations drift apart in the first place.
