### PR TITLE
build: Pin smt-switch and fmt by commit hash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,8 +124,7 @@ if(NOT fmt_FOUND)
   FetchContent_Declare(
     fmt
     GIT_REPOSITORY https://github.com/fmtlib/fmt
-    GIT_TAG 12.2.0
-    GIT_SHALLOW TRUE
+    GIT_TAG 1be298e1bd68957e4cd352e1f676f00e07dcfb57 # 12.2.0
   )
   FetchContent_MakeAvailable(fmt)
   # A fetched fmt is built in-tree, so its headers are not treated as system

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-smt_switch_version=v1.1.4
+smt_switch_version=460b5fdc8a048cdc2196de5bb27be2c2c9e6f90a # v1.1.4
 
 # Keep the invocation directory to resolve relative path arguments against,
 # since they would otherwise be taken relative to the smt-switch checkout that


### PR DESCRIPTION
A tag name is a movable ref, so neither pin actually pinned anything.
Annotation is no exception: it records a tagger, date and message, but
the ref can still be force-pushed. fmt's 58 tags are all lightweight,
so they do not even carry that record.

v1.1.4 is annotated, so `git ls-remote` reports both the tag object
(51304f99) and the commit it names (460b5fdc); the commit is what gets
pinned.

GIT_SHALLOW has to go with it: a shallow clone accepts only branch
names and tags for GIT_TAG, not a commit hash.