### PR TITLE
ci: Verify the SHA256 of the MathSAT download

### DIFF
--- a/ci-scripts/setup-msat.sh
+++ b/ci-scripts/setup-msat.sh
@@ -16,9 +16,39 @@ EOF
   exit 0
 }
 
+die() {
+  echo "*** $0: $*" >&2
+  exit 1
+}
+
+# Aborts unless archive $1 has the expected SHA256 digest $2, discarding
+# $dir so that a rerun starts over. macOS has no sha256sum, so fall back
+# to the shasum that ships with its Perl.
+verify_sha256() {
+  local actual
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$1" | cut -d ' ' -f 1)"
+  else
+    actual="$(shasum -a 256 "$1" | cut -d ' ' -f 1)"
+  fi
+  if [[ $actual != "$2" ]]; then
+    echo "Checksum mismatch for $msat_archive"
+    echo "  expected SHA256: $2"
+    echo "  actual SHA256:   $actual"
+    rm -rf "$dir"
+    exit 1
+  fi
+}
+
 get_msat=default
 msat_version="5.6.12"
 msat_release_url="https://mathsat.fbk.eu/release/mathsat"
+# Digests of the $msat_version archives. Update them together with
+# msat_version, otherwise the download stops verifying.
+msat_sha256_linux_x86_64="\
+1de984ed8500ce0895970116d57f73b381929fa6600d4e29b6beb3042f2b721b"
+msat_sha256_macos="\
+28fe0711bdd920217af706b07983f033470efc2ea15a4563397e1a930b75e9f5"
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -42,20 +72,28 @@ if [[ $get_msat != y ]]; then
 fi
 
 if [[ ! -d $dir ]]; then
-  mkdir -p "$dir"
-  cd "$dir"
-  if [[ $OSTYPE == linux* ]]; then
-    wget -O mathsat.tar.gz $msat_release_url-$msat_version-linux-x86_64.tar.gz
+  # Each platform picks its archive and that archive's digest together.
+  if [[ $OSTYPE == linux* || $OSTYPE == cygwin* ]]; then
+    msat_archive=$msat_release_url-$msat_version-linux-x86_64.tar.gz
+    msat_sha256=$msat_sha256_linux_x86_64
   elif [[ $OSTYPE == darwin* ]]; then
-    wget -O mathsat.tar.gz $msat_release_url-$msat_version-macos.tar.gz
-  elif [[ $OSTYPE == msys* ]]; then
-    wget -O mathsat.tar.gz $msat_release_url-$msat_version-win64-msvc.zip
-  elif [[ $OSTYPE == cygwin* ]]; then
-    wget -O mathsat.tar.gz $msat_release_url-$msat_version-linux-x86_64.tar.gz
+    msat_archive=$msat_release_url-$msat_version-macos.tar.gz
+    msat_sha256=$msat_sha256_macos
   else
     echo "Unrecognized OSTYPE=$OSTYPE"
     exit 1
   fi
+
+  # Catches a platform case added without a digest to pin its archive.
+  if [[ -z $msat_sha256 ]]; then
+    echo "No SHA256 digest is pinned for $msat_archive"
+    exit 1
+  fi
+
+  mkdir -p "$dir"
+  cd "$dir"
+  wget -O mathsat.tar.gz "$msat_archive"
+  verify_sha256 mathsat.tar.gz "$msat_sha256"
 
   tar -xf mathsat.tar.gz --strip-components 1
   rm mathsat.tar.gz


### PR DESCRIPTION
A fixed version number does not pin the artifact's content, and this is a binary that gets statically linked into the shipped executable.

macOS has no sha256sum, so the check falls back to the shasum that ships with its Perl.

The msys case goes: its URL 404s upstream and the download is untarred, so it could never have worked for a zip, and nothing exercises it. The remaining "Unrecognized OSTYPE" error is accurate for Windows.

die has been called by the argument loop since #279 without ever being defined.