### PR TITLE
ci: Run clang-format on C/C++ header templates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,11 @@ repos:
     hooks:
       - id: clang-format
         exclude: "^(contrib/|tests/encoders/inputs/coreir/)"
+        # identify tags a file by its last extension only, so *.h.in gets no
+        # c++ tag. Selecting by path covers the templates too, at the cost of
+        # keeping this extension list current by hand.
+        types_or: [text]
+        files: '\.(c|cc|cpp|h|hpp)(\.in)?$'
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.5
     hooks:


### PR DESCRIPTION
identify tags a file by its last extension only, so options/version.h.in never got a c++ tag and the clang-format hook never saw it. Selecting by path also requires overriding types_or, since the hook's file filters are conjunctive.