### PR TITLE
feature: Honor Btor2 fair lines when checking justice properties

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,12 @@ if(PONO_STATIC_EXEC STREQUAL "YES")
   endif()
 endif()
 
+# Several switches dispatch on an option enum and rely on covering every
+# enumerator, so adding one without a case has to be a compile error rather
+# than a silently skipped branch. Not implied by the default flags, which do
+# not include -Wall.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=switch")
+
 if(WITH_BOOLECTOR)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWITH_BOOLECTOR")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,9 +342,11 @@ add_subdirectory(tests EXCLUDE_FROM_ALL)
 add_executable(pono-bin "${PROJECT_SOURCE_DIR}/pono.cpp")
 set_target_properties(pono-bin PROPERTIES OUTPUT_NAME pono)
 
-# test_version runs the executable itself, so `check` has to build it. Wired
-# up here because pono-bin does not exist yet while tests/ is processed.
+# test_version and test_justice_cli run the executable itself, so building
+# them has to build it too, or they would test a stale or missing binary.
+# Wired up here because pono-bin does not exist yet while tests/ is processed.
 add_dependencies(check pono-bin)
+add_dependencies(test_justice_cli pono-bin)
 
 target_include_directories(
   pono-bin

--- a/engines/kliveness.cpp
+++ b/engines/kliveness.cpp
@@ -17,14 +17,20 @@
 
 #include "kliveness.h"
 
+#include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <map>
+#include <string>
 
+#include "core/prop.h"
+#include "core/ts.h"
 #include "engines/bmc.h"
 #include "modifiers/liveness_to_safety_translator.h"
 #include "modifiers/mod_ts_prop.h"
 #include "modifiers/static_coi.h"
 #include "smt/available_solvers.h"
+#include "utils/exceptions.h"
 #include "utils/logger.h"
 #include "utils/make_provers.h"
 namespace pono {
@@ -36,7 +42,9 @@ KLiveness::KLiveness(const LivenessProperty & p,
     : super(p, ts, solver, opt)
 {
   if (justice_conditions_.size() > 1) {
-    throw PonoException("k-liveness only supports one justice condition.");
+    throw PonoException(
+        "k-liveness only supports one liveness condition, including fairness "
+        "constraints.");
   }
   // copied from pono.cpp
   if (opt.static_coi_) {

--- a/frontends/btor2_encoder.cpp
+++ b/frontends/btor2_encoder.cpp
@@ -18,10 +18,14 @@
 
 #include <algorithm>
 #include <cassert>
-#include <iostream>
+#include <cstdio>
 #include <iterator>
+#include <unordered_set>
+#include <utility>
 
-#include "smt-switch/utils.h"
+#include "btor2parser.h"
+#include "smt-switch/smt.h"
+#include "utils/exceptions.h"
 #include "utils/logger.h"
 
 using namespace smt;
@@ -435,8 +439,8 @@ void BTOR2Encoder::parse(const std::string filename)
                      std::back_inserter(justice),
                      [&](auto t) { return bv_to_bool(t); });
     } else if (bt2_line->tag == BTOR2_TAG_fair) {
-      std::cerr << "Warning: ignoring fair term" << std::endl;
-      fairvec_.push_back(termargs[0]);
+      // Keep terms_ raw: other lines may reference this id as a bitvector.
+      fairvec_.push_back(bv_to_bool(termargs[0]));
       terms_[bt2_line->id] = termargs[0];
     } else if (bt2_line->constant) {
       terms_[bt2_line->id] = solver_->make_term(

--- a/pono.cpp
+++ b/pono.cpp
@@ -16,14 +16,23 @@
 
 #include <cassert>
 #include <csignal>
+#include <exception>
 #include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
 
 #ifdef WITH_PROFILING
 #include <gperftools/profiler.h>
 #endif
 
 #include "core/fts.h"
+#include "core/prop.h"
+#include "core/proverresult.h"
+#include "core/rts.h"
+#include "core/ts.h"
 #include "engines/kliveness.h"
+#include "engines/prover.h"
 #include "frontends/btor2_encoder.h"
 #include "frontends/smv_encoder.h"
 #include "frontends/vmt_encoder.h"
@@ -36,8 +45,10 @@
 #include "printers/btor2_witness_printer.h"
 #include "printers/vcd_witness_printer.h"
 #include "smt-switch/logging_solver.h"
+#include "smt-switch/smt.h"
 #include "smt-switch/utils.h"
 #include "smt/available_solvers.h"
+#include "utils/exceptions.h"
 #include "utils/logger.h"
 #include "utils/make_provers.h"
 #include "utils/timestamp.h"
@@ -242,6 +253,11 @@ int main(int argc, char ** argv)
   // set logger verbosity -- can only be set once
   logger.set_verbosity(pono_options.verbosity_);
 
+  // Btor2 output labels a property by kind and index. Built here, next to the
+  // options, so the error paths below cannot disagree with the result path.
+  const string prop_label =
+      (pono_options.justice_ ? "j" : "b") + to_string(pono_options.prop_idx_);
+
   // For profiling: set signal handlers for common signals to abort
   // program.  This is necessary to gracefully stop profiling when,
   // e.g., an external time limit is enforced to stop the program.
@@ -317,46 +333,53 @@ int main(int argc, char ** argv)
             + pono_options.filename_ + " (" + to_string(num_props) + ")");
       }
 
-      Term prop;
-      if (pono_options.justice_) {
-        // The selected algorithm can modify the transition system in place.
-        switch (pono_options.justice_translator_) {
-          case pono::LIVENESS_TO_SAFETY:
-            if (pono_options.static_coi_) {
-              StaticConeOfInfluence coi(fts,
-                                        justicevec[pono_options.prop_idx_],
-                                        pono_options.verbosity_);
-            }
-            prop = LivenessToSafetyTranslator{}.translate(
-                fts, justicevec[pono_options.prop_idx_]);
-            break;
-        }
-      } else {
-        prop = propvec[pono_options.prop_idx_];
-      }
-
       vector<UnorderedTermMap> cex;
-      if (pono_options.justice_
-          && pono_options.justice_translator_ == KLIVENESS) {
-        LivenessProperty justice_prop(s, justicevec[pono_options.prop_idx_]);
-        KLiveness justice_prover(justice_prop, fts, s, pono_options);
-        res = justice_prover.check_until(pono_options.bound_);
-        if (res == ProverResult::FALSE && pono_options.witness_) {
-          if (!justice_prover.witness(cex)) {
-            logger.log(0,
-                       "Only got a partial witness from engine. "
-                       "Not suitable for printing.");
+      if (pono_options.justice_) {
+        // Fairness constraints are file-global, and a counterexample must
+        // satisfy them as often as the property's own justice conditions, so
+        // both sets are checked together.
+        TermVec conditions = justicevec[pono_options.prop_idx_];
+        conditions.insert(conditions.end(),
+                          btor_enc.fairvec().begin(),
+                          btor_enc.fairvec().end());
+        switch (pono_options.justice_translator_) {
+          case pono::LIVENESS_TO_SAFETY: {
+            // These modify the transition system in place.
+            if (pono_options.static_coi_) {
+              StaticConeOfInfluence coi(
+                  fts, conditions, pono_options.verbosity_);
+            }
+            Term prop = LivenessToSafetyTranslator{}.translate(fts, conditions);
+            res = check_prop(pono_options, prop, fts, s, cex);
+            break;
+          }
+          case pono::KLIVENESS: {
+            LivenessProperty justice_prop(s, conditions);
+            KLiveness justice_prover(justice_prop, fts, s, pono_options);
+            res = justice_prover.check_until(pono_options.bound_);
+            if (res == ProverResult::FALSE && pono_options.witness_
+                && !justice_prover.witness(cex)) {
+              logger.log(0,
+                         "Only got a partial witness from engine. "
+                         "Not suitable for printing.");
+            }
+            break;
           }
         }
       } else {
+        if (!btor_enc.fairvec().empty()) {
+          logger.log(0,
+                     "Warning: ignoring {} fair line(s); fairness constraints "
+                     "only apply to justice properties (--justice).",
+                     btor_enc.fairvec().size());
+        }
+        Term prop = propvec[pono_options.prop_idx_];
         res = check_prop(pono_options, prop, fts, s, cex);
       }
       // we assume that a prover never returns 'ERROR'
       assert(res != ERROR);
 
       // print btor output
-      const string prop_label = (pono_options.justice_ ? "j" : "b")
-                                + to_string(pono_options.prop_idx_);
       if (res == FALSE) {
         cout << "sat" << endl;
         cout << prop_label << endl;
@@ -392,6 +415,11 @@ int main(int argc, char ** argv)
       }
 
     } else if (file_ext == "smv" || file_ext == "vmt" || file_ext == "smt2") {
+      if (pono_options.justice_) {
+        throw PonoException("--justice is not supported for " + file_ext
+                            + " input; the encoder for this format parses "
+                              "only invariant properties");
+      }
       logger.log(2, "Parsing SMV/VMT file: {}", pono_options.filename_);
       RelationalTransitionSystem rts(s);
       TermVec propvec;
@@ -451,20 +479,20 @@ int main(int argc, char ** argv)
   catch (PonoException & ce) {
     cerr << ce.what() << endl;
     cout << "error" << endl;
-    cout << "b" << pono_options.prop_idx_ << endl;
+    cout << prop_label << endl;
     res = ProverResult::ERROR;
   }
   catch (SmtException & se) {
     cerr << se.what() << endl;
     cout << "error" << endl;
-    cout << "b" << pono_options.prop_idx_ << endl;
+    cout << prop_label << endl;
     res = ProverResult::ERROR;
   }
   catch (std::exception & e) {
     cerr << "Caught generic exception..." << endl;
     cerr << e.what() << endl;
     cout << "error" << endl;
-    cout << "b" << pono_options.prop_idx_ << endl;
+    cout << prop_label << endl;
     res = ProverResult::ERROR;
   }
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -96,4 +96,56 @@ set_tests_properties(
   PROPERTIES PASS_REGULAR_EXPRESSION "^${PONO_RELEASE_VERSION_REGEX}"
 )
 
+# Btor2 fairness constraints reach the prover only through the driver, so
+# these cover the wiring that the unit tests above cannot. Each asserts on
+# output rather than the return code, which is non-zero for the error cases.
+set(BTOR2_INPUT_DIR "${PROJECT_SOURCE_DIR}/tests/encoders/inputs/btor2")
+
+# The justice condition alone is violated, so proving the property depends on
+# the fair line being honored. k-induction is needed because bmc, the default
+# engine, cannot prove a property.
+add_test(
+  NAME test_justice_fairness
+  COMMAND pono-bin --justice --engine ind "${BTOR2_INPUT_DIR}/fair_frozen_mode.btor2"
+)
+set_tests_properties(test_justice_fairness PROPERTIES PASS_REGULAR_EXPRESSION "unsat\nj0")
+
+# k-liveness counts one condition, so it has to reject a fairness constraint
+# rather than silently check the justice condition alone.
+add_test(
+  NAME test_justice_fairness_klive
+  COMMAND pono-bin --justice --justice-translator klive "${BTOR2_INPUT_DIR}/fair_frozen_mode.btor2"
+)
+set_tests_properties(test_justice_fairness_klive PROPERTIES PASS_REGULAR_EXPRESSION "fairness")
+
+# Fair lines do not constrain safety checking, so checking a bad property has
+# to say that they are being ignored.
+add_test(
+  NAME test_fairness_ignored_without_justice
+  COMMAND pono-bin "${BTOR2_INPUT_DIR}/fair_with_bad_property.btor2"
+)
+set_tests_properties(
+  test_fairness_ignored_without_justice
+  PROPERTIES PASS_REGULAR_EXPRESSION "ignoring 1 fair line"
+)
+
+# Errors label the property by the kind that was requested, so a failure
+# under --justice reports j, not b.
+add_test(
+  NAME test_justice_error_label
+  COMMAND pono-bin --justice --prop 5 "${BTOR2_INPUT_DIR}/fair_frozen_mode.btor2"
+)
+set_tests_properties(test_justice_error_label PROPERTIES PASS_REGULAR_EXPRESSION "error\nj5")
+
+# The SMV and VMT encoders parse no liveness properties, so --justice has to
+# be refused instead of silently checking an invariant property.
+add_test(
+  NAME test_justice_rejected_for_smv
+  COMMAND pono-bin --justice "${PROJECT_SOURCE_DIR}/tests/encoders/inputs/smv/counter.smv"
+)
+set_tests_properties(
+  test_justice_rejected_for_smv
+  PROPERTIES PASS_REGULAR_EXPRESSION "--justice is not supported for smv"
+)
+
 add_subdirectory(encoders)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -96,56 +96,16 @@ set_tests_properties(
   PROPERTIES PASS_REGULAR_EXPRESSION "^${PONO_RELEASE_VERSION_REGEX}"
 )
 
-# Btor2 fairness constraints reach the prover only through the driver, so
-# these cover the wiring that the unit tests above cannot. Each asserts on
-# output rather than the return code, which is non-zero for the error cases.
-set(BTOR2_INPUT_DIR "${PROJECT_SOURCE_DIR}/tests/encoders/inputs/btor2")
-
-# The justice condition alone is violated, so proving the property depends on
-# the fair line being honored. k-induction is needed because bmc, the default
-# engine, cannot prove a property.
-add_test(
-  NAME test_justice_fairness
-  COMMAND pono-bin --justice --engine ind "${BTOR2_INPUT_DIR}/fair_frozen_mode.btor2"
-)
-set_tests_properties(test_justice_fairness PROPERTIES PASS_REGULAR_EXPRESSION "unsat\nj0")
-
-# k-liveness counts one condition, so it has to reject a fairness constraint
-# rather than silently check the justice condition alone.
-add_test(
-  NAME test_justice_fairness_klive
-  COMMAND pono-bin --justice --justice-translator klive "${BTOR2_INPUT_DIR}/fair_frozen_mode.btor2"
-)
-set_tests_properties(test_justice_fairness_klive PROPERTIES PASS_REGULAR_EXPRESSION "fairness")
-
-# Fair lines do not constrain safety checking, so checking a bad property has
-# to say that they are being ignored.
-add_test(
-  NAME test_fairness_ignored_without_justice
-  COMMAND pono-bin "${BTOR2_INPUT_DIR}/fair_with_bad_property.btor2"
-)
-set_tests_properties(
-  test_fairness_ignored_without_justice
-  PROPERTIES PASS_REGULAR_EXPRESSION "ignoring 1 fair line"
-)
-
-# Errors label the property by the kind that was requested, so a failure
-# under --justice reports j, not b.
-add_test(
-  NAME test_justice_error_label
-  COMMAND pono-bin --justice --prop 5 "${BTOR2_INPUT_DIR}/fair_frozen_mode.btor2"
-)
-set_tests_properties(test_justice_error_label PROPERTIES PASS_REGULAR_EXPRESSION "error\nj5")
-
-# The SMV and VMT encoders parse no liveness properties, so --justice has to
-# be refused instead of silently checking an invariant property.
-add_test(
-  NAME test_justice_rejected_for_smv
-  COMMAND pono-bin --justice "${PROJECT_SOURCE_DIR}/tests/encoders/inputs/smv/counter.smv"
-)
-set_tests_properties(
-  test_justice_rejected_for_smv
-  PROPERTIES PASS_REGULAR_EXPRESSION "--justice is not supported for smv"
+# Tests that run the executable itself, rather than linking the library. The
+# executable's path comes from a generator expression because pono-bin is
+# defined only after this directory is processed, and the input directory is
+# passed in because the test cannot derive it.
+pono_add_test(test_justice_cli)
+target_compile_definitions(
+  test_justice_cli
+  PRIVATE
+    PONO_BIN="$<TARGET_FILE:pono-bin>"
+    PONO_INPUT_DIR="${PROJECT_SOURCE_DIR}/tests/encoders/inputs"
 )
 
 add_subdirectory(encoders)

--- a/tests/encoders/CMakeLists.txt
+++ b/tests/encoders/CMakeLists.txt
@@ -1,6 +1,7 @@
 include_directories("${PROJECT_SOURCE_DIR}/tests/encoders")
 
 pono_add_test(test_btor2)
+pono_add_test(test_btor2_liveness)
 pono_add_test(test_coreir)
 pono_add_test(test_smv)
 

--- a/tests/encoders/inputs/btor2/fair_contradictory.btor2
+++ b/tests/encoders/inputs/btor2/fair_contradictory.btor2
@@ -1,0 +1,11 @@
+; The two fairness constraints (GF mode and GF !mode) cannot both hold on a
+; trace where mode never changes, so no trace is fair and every liveness
+; result under them holds vacuously. Pono does not flag this, matching how it
+; treats an unsatisfiable set of constraint lines in safety checking.
+1 sort bitvec 1
+2 state 1 mode
+3 next 1 2 2
+4 not 1 2
+5 justice 1 2
+6 fair 2
+7 fair 4

--- a/tests/encoders/inputs/btor2/fair_frozen_mode.btor2
+++ b/tests/encoders/inputs/btor2/fair_frozen_mode.btor2
@@ -1,0 +1,10 @@
+; mode is chosen nondeterministically in the initial state and never changes.
+; The justice condition (GF mode) alone admits a lasso, at mode=1, and the
+; fairness constraint (GF !mode) alone admits one, at mode=0, but no trace
+; satisfies both infinitely often.
+1 sort bitvec 1
+2 state 1 mode
+3 next 1 2 2
+4 not 1 2
+5 justice 1 2
+6 fair 4

--- a/tests/encoders/inputs/btor2/fair_with_bad_property.btor2
+++ b/tests/encoders/inputs/btor2/fair_with_bad_property.btor2
@@ -1,0 +1,9 @@
+; A safety property alongside a fair line. Fairness constrains liveness
+; checking only, so checking the bad property here ignores the fair line and
+; warns about it.
+1 sort bitvec 1
+2 state 1 mode
+3 next 1 2 2
+4 not 1 2
+5 bad 4
+6 fair 4

--- a/tests/encoders/inputs/btor2/justice_only.btor2
+++ b/tests/encoders/inputs/btor2/justice_only.btor2
@@ -1,0 +1,6 @@
+; Same frozen mode bit as fair_frozen_mode.btor2, but with no fair line, so
+; the justice condition (GF mode) is violated by the lasso at mode=1.
+1 sort bitvec 1
+2 state 1 mode
+3 next 1 2 2
+4 justice 1 2

--- a/tests/encoders/test_btor2_liveness.cpp
+++ b/tests/encoders/test_btor2_liveness.cpp
@@ -31,6 +31,17 @@ class Btor2LivenessUnitTests : public ::testing::Test,
     return string(STRFY(PONO_SRC_DIR)) + "/tests/encoders/inputs/btor2/" + name;
   }
 
+  /** Boolector treats booleans and width-1 bitvectors as the same sort, so
+   *  terms built by bv_to_bool report back as bitvectors there. The logging
+   *  wrapper tracks sorts itself, which keeps them as the encoder built them.
+   */
+  SmtSolver make_solver() const
+  {
+    SmtSolver s = create_solver(GetParam(), GetParam() == BTOR);
+    s->set_opt("incremental", "true");
+    return s;
+  }
+
   /** The condition set a generalized-Buchi search is given for the property
    *  at index 0: its justice conditions plus the file's fairness constraints,
    *  matching how pono.cpp combines them.
@@ -49,7 +60,7 @@ class Btor2LivenessUnitTests : public ::testing::Test,
 // encoder has to convert them the same way it converts justice conditions.
 TEST_P(Btor2LivenessUnitTests, FairTermsAreBoolSorted)
 {
-  SmtSolver s = create_solver(GetParam());
+  SmtSolver s = make_solver();
   FunctionalTransitionSystem fts(s);
   BTOR2Encoder be(input_path("fair_frozen_mode.btor2"), fts);
   ASSERT_EQ(be.fairvec().size(), 1);
@@ -65,8 +76,7 @@ TEST_P(Btor2LivenessUnitTests, FairnessRestrictsCounterexample)
   const string filename = input_path("fair_frozen_mode.btor2");
   const int bound = 10;
 
-  SmtSolver justice_solver = create_solver(GetParam());
-  justice_solver->set_opt("incremental", "true");
+  SmtSolver justice_solver = make_solver();
   FunctionalTransitionSystem justice_fts(justice_solver);
   BTOR2Encoder justice_be(filename, justice_fts);
   Term justice_term = LivenessToSafetyTranslator{}.translate(
@@ -76,8 +86,7 @@ TEST_P(Btor2LivenessUnitTests, FairnessRestrictsCounterexample)
   EXPECT_EQ(justice_bmc.check_until(bound), ProverResult::FALSE);
 
   // A separate solver, because the translation adds equally named variables.
-  SmtSolver fair_solver = create_solver(GetParam());
-  fair_solver->set_opt("incremental", "true");
+  SmtSolver fair_solver = make_solver();
   FunctionalTransitionSystem fair_fts(fair_solver);
   BTOR2Encoder fair_be(filename, fair_fts);
   Term fair_term =
@@ -87,8 +96,7 @@ TEST_P(Btor2LivenessUnitTests, FairnessRestrictsCounterexample)
   EXPECT_NE(fair_bmc.check_until(bound), ProverResult::FALSE);
 
   // And no deeper counterexample exists either.
-  SmtSolver ind_solver = create_solver(GetParam());
-  ind_solver->set_opt("incremental", "true");
+  SmtSolver ind_solver = make_solver();
   FunctionalTransitionSystem ind_fts(ind_solver);
   BTOR2Encoder ind_be(filename, ind_fts);
   Term ind_term =
@@ -104,8 +112,7 @@ TEST_P(Btor2LivenessUnitTests, FairnessRestrictsCounterexample)
 // lines in safety checking.
 TEST_P(Btor2LivenessUnitTests, ContradictoryFairnessProvesVacuously)
 {
-  SmtSolver s = create_solver(GetParam());
-  s->set_opt("incremental", "true");
+  SmtSolver s = make_solver();
   FunctionalTransitionSystem fts(s);
   BTOR2Encoder be(input_path("fair_contradictory.btor2"), fts);
   ASSERT_EQ(be.fairvec().size(), 2);
@@ -121,8 +128,7 @@ TEST_P(Btor2LivenessUnitTests, ContradictoryFairnessProvesVacuously)
 // than check the justice condition on its own.
 TEST_P(Btor2LivenessUnitTests, KLivenessRejectsFairness)
 {
-  SmtSolver s = create_solver(GetParam());
-  s->set_opt("incremental", "true");
+  SmtSolver s = make_solver();
   FunctionalTransitionSystem fts(s);
   BTOR2Encoder be(input_path("fair_frozen_mode.btor2"), fts);
   ASSERT_EQ(be.justicevec().at(0).size(), 1);
@@ -142,8 +148,7 @@ TEST_P(Btor2LivenessUnitTests, KLivenessRejectsFairness)
 // the counterexample the fairness constraint ruled out above is found again.
 TEST_P(Btor2LivenessUnitTests, JusticeOnlyIsUnaffected)
 {
-  SmtSolver s = create_solver(GetParam());
-  s->set_opt("incremental", "true");
+  SmtSolver s = make_solver();
   FunctionalTransitionSystem fts(s);
   BTOR2Encoder be(input_path("justice_only.btor2"), fts);
   EXPECT_TRUE(be.fairvec().empty());

--- a/tests/encoders/test_btor2_liveness.cpp
+++ b/tests/encoders/test_btor2_liveness.cpp
@@ -1,0 +1,162 @@
+#include <string>
+
+#include "core/fts.h"
+#include "core/prop.h"
+#include "core/proverresult.h"
+#include "engines/bmc.h"
+#include "engines/kinduction.h"
+#include "engines/kliveness.h"
+#include "frontends/btor2_encoder.h"
+#include "gtest/gtest.h"
+#include "modifiers/liveness_to_safety_translator.h"
+#include "options/options.h"
+#include "smt-switch/smt.h"
+#include "smt/available_solvers.h"
+#include "test_encoder_inputs.h"
+#include "utils/exceptions.h"
+
+using namespace pono;
+using namespace smt;
+using namespace std;
+
+namespace pono_tests {
+
+class Btor2LivenessUnitTests : public ::testing::Test,
+                               public ::testing::WithParamInterface<SolverEnum>
+{
+ protected:
+  // PONO_SRC_DIR is a macro set using CMake PROJECT_SRC_DIR
+  string input_path(const string & name) const
+  {
+    return string(STRFY(PONO_SRC_DIR)) + "/tests/encoders/inputs/btor2/" + name;
+  }
+
+  /** The condition set a generalized-Buchi search is given for the property
+   *  at index 0: its justice conditions plus the file's fairness constraints,
+   *  matching how pono.cpp combines them.
+   */
+  TermVec all_conditions(const BTOR2Encoder & be) const
+  {
+    TermVec conditions = be.justicevec().at(0);
+    conditions.insert(
+        conditions.end(), be.fairvec().begin(), be.fairvec().end());
+    return conditions;
+  }
+};
+
+// Btor2 fair operands are always bitvectors of width 1, but the liveness to
+// safety translation combines conditions with boolean operators, so the
+// encoder has to convert them the same way it converts justice conditions.
+TEST_P(Btor2LivenessUnitTests, FairTermsAreBoolSorted)
+{
+  SmtSolver s = create_solver(GetParam());
+  FunctionalTransitionSystem fts(s);
+  BTOR2Encoder be(input_path("fair_frozen_mode.btor2"), fts);
+  ASSERT_EQ(be.fairvec().size(), 1);
+  EXPECT_EQ(be.fairvec()[0]->get_sort()->get_sort_kind(), SortKind::BOOL);
+}
+
+// The justice condition alone is violated by the lasso at mode=1, but that
+// lasso never satisfies the fairness constraint, so adding the constraint
+// removes the only counterexample. This is what makes the union of the two
+// condition sets more than a no-op.
+TEST_P(Btor2LivenessUnitTests, FairnessRestrictsCounterexample)
+{
+  const string filename = input_path("fair_frozen_mode.btor2");
+  const int bound = 10;
+
+  SmtSolver justice_solver = create_solver(GetParam());
+  justice_solver->set_opt("incremental", "true");
+  FunctionalTransitionSystem justice_fts(justice_solver);
+  BTOR2Encoder justice_be(filename, justice_fts);
+  Term justice_term = LivenessToSafetyTranslator{}.translate(
+      justice_fts, justice_be.justicevec().at(0));
+  SafetyProperty justice_prop(justice_solver, justice_term);
+  Bmc justice_bmc(justice_prop, justice_fts, justice_solver);
+  EXPECT_EQ(justice_bmc.check_until(bound), ProverResult::FALSE);
+
+  // A separate solver, because the translation adds equally named variables.
+  SmtSolver fair_solver = create_solver(GetParam());
+  fair_solver->set_opt("incremental", "true");
+  FunctionalTransitionSystem fair_fts(fair_solver);
+  BTOR2Encoder fair_be(filename, fair_fts);
+  Term fair_term =
+      LivenessToSafetyTranslator{}.translate(fair_fts, all_conditions(fair_be));
+  SafetyProperty fair_prop(fair_solver, fair_term);
+  Bmc fair_bmc(fair_prop, fair_fts, fair_solver);
+  EXPECT_NE(fair_bmc.check_until(bound), ProverResult::FALSE);
+
+  // And no deeper counterexample exists either.
+  SmtSolver ind_solver = create_solver(GetParam());
+  ind_solver->set_opt("incremental", "true");
+  FunctionalTransitionSystem ind_fts(ind_solver);
+  BTOR2Encoder ind_be(filename, ind_fts);
+  Term ind_term =
+      LivenessToSafetyTranslator{}.translate(ind_fts, all_conditions(ind_be));
+  SafetyProperty ind_prop(ind_solver, ind_term);
+  KInduction ind(ind_prop, ind_fts, ind_solver);
+  EXPECT_EQ(ind.check_until(bound), ProverResult::TRUE);
+}
+
+// Fairness constraints that cannot all recur exclude every trace, so the
+// property holds for want of any fair counterexample. Pono reports this as a
+// plain proof, the same way it treats an unsatisfiable set of constraint
+// lines in safety checking.
+TEST_P(Btor2LivenessUnitTests, ContradictoryFairnessProvesVacuously)
+{
+  SmtSolver s = create_solver(GetParam());
+  s->set_opt("incremental", "true");
+  FunctionalTransitionSystem fts(s);
+  BTOR2Encoder be(input_path("fair_contradictory.btor2"), fts);
+  ASSERT_EQ(be.fairvec().size(), 2);
+  Term prop_term =
+      LivenessToSafetyTranslator{}.translate(fts, all_conditions(be));
+  SafetyProperty prop(s, prop_term);
+  KInduction ind(prop, fts, s);
+  EXPECT_EQ(ind.check_until(10), ProverResult::TRUE);
+}
+
+// k-liveness counts observations of a single condition, so it cannot honor a
+// fairness constraint alongside a justice condition. It has to say so rather
+// than check the justice condition on its own.
+TEST_P(Btor2LivenessUnitTests, KLivenessRejectsFairness)
+{
+  SmtSolver s = create_solver(GetParam());
+  s->set_opt("incremental", "true");
+  FunctionalTransitionSystem fts(s);
+  BTOR2Encoder be(input_path("fair_frozen_mode.btor2"), fts);
+  ASSERT_EQ(be.justicevec().at(0).size(), 1);
+  ASSERT_EQ(be.fairvec().size(), 1);
+  LivenessProperty prop(s, all_conditions(be));
+  try {
+    KLiveness kliveness(prop, fts, s, PonoOptions());
+    FAIL() << "expected KLiveness to reject the fairness constraint";
+  }
+  catch (const PonoException & e) {
+    EXPECT_NE(string(e.what()).find("fairness"), string::npos)
+        << "message should name fairness constraints, got: " << e.what();
+  }
+}
+
+// Without a fair line the condition set is just the justice conditions, so
+// the counterexample the fairness constraint ruled out above is found again.
+TEST_P(Btor2LivenessUnitTests, JusticeOnlyIsUnaffected)
+{
+  SmtSolver s = create_solver(GetParam());
+  s->set_opt("incremental", "true");
+  FunctionalTransitionSystem fts(s);
+  BTOR2Encoder be(input_path("justice_only.btor2"), fts);
+  EXPECT_TRUE(be.fairvec().empty());
+  EXPECT_EQ(all_conditions(be), be.justicevec().at(0));
+  Term prop_term =
+      LivenessToSafetyTranslator{}.translate(fts, all_conditions(be));
+  SafetyProperty prop(s, prop_term);
+  Bmc bmc(prop, fts, s);
+  EXPECT_EQ(bmc.check_until(10), ProverResult::FALSE);
+}
+
+INSTANTIATE_TEST_SUITE_P(ParameterizedSolverBtor2LivenessUnitTests,
+                         Btor2LivenessUnitTests,
+                         testing::ValuesIn(available_solver_enums()));
+
+}  // namespace pono_tests

--- a/tests/encoders/test_btor2_liveness.cpp
+++ b/tests/encoders/test_btor2_liveness.cpp
@@ -160,8 +160,13 @@ TEST_P(Btor2LivenessUnitTests, JusticeOnlyIsUnaffected)
   EXPECT_EQ(bmc.check_until(10), ProverResult::FALSE);
 }
 
-INSTANTIATE_TEST_SUITE_P(ParameterizedSolverBtor2LivenessUnitTests,
+// The instantiation name is prefixed to the suite name, so naming it after
+// the suite would only repeat it; there is one instantiation, so it is left
+// empty. The generator suffixes each case with its solver instead of an
+// index, which is what identifies a case in a failure report.
+INSTANTIATE_TEST_SUITE_P(,
                          Btor2LivenessUnitTests,
-                         testing::ValuesIn(available_solver_enums()));
+                         testing::ValuesIn(available_solver_enums()),
+                         testing::PrintToStringParamName());
 
 }  // namespace pono_tests

--- a/tests/test_justice_cli.cpp
+++ b/tests/test_justice_cli.cpp
@@ -14,6 +14,13 @@ using namespace std;
 
 namespace pono_tests {
 
+/** The outcome of one run of the pono executable. */
+struct PonoRun
+{
+  string output;   ///< standard output and standard error, interleaved
+  bool succeeded;  ///< whether the process exited with a status of zero
+};
+
 class JusticeCliUnitTests : public ::testing::Test
 {
  protected:
@@ -38,13 +45,13 @@ class JusticeCliUnitTests : public ::testing::Test
     return quoted + "'";
   }
 
-  /** Runs pono and returns its output, with the standard error stream
-   *  redirected into it, since results go to standard output but the
+  /** Runs pono and returns what it printed, with the standard error stream
+   *  redirected into the output, since results go to standard output but the
    *  diagnostics that accompany them go to standard error.
    *  @param args the command line arguments to pass
-   *  @return the combined output
+   *  @return the run's output and whether it exited cleanly
    */
-  static string run_pono(const vector<string> & args)
+  static PonoRun run_pono(const vector<string> & args)
   {
     // PONO_BIN is a macro set using CMake to the executable's location.
     string command = quote(PONO_BIN);
@@ -62,8 +69,9 @@ class JusticeCliUnitTests : public ::testing::Test
     while (fgets(buffer, sizeof(buffer), pipe)) {
       output += buffer;
     }
-    pclose(pipe);
-    return output;
+    // Zero is the only wait status standing for a clean exit, so comparing
+    // against it covers an error result and a fatal signal alike.
+    return { output, pclose(pipe) == 0 };
   }
 
   static ::testing::AssertionResult contains(const string & output,
@@ -76,6 +84,21 @@ class JusticeCliUnitTests : public ::testing::Test
            << "expected to find \"" << expected << "\" in output:\n"
            << output;
   }
+
+  /** Asserts that pono rejected a command line and said why.
+   *
+   *  The message reaches the output in either build, by different routes:
+   *  pono.cpp's top-level try/catch prints it and an error result, but that
+   *  handler is guarded by NDEBUG so a debugger or sanitizer sees the
+   *  exception, so in a debug build it escapes and the terminate handler
+   *  prints the same message as the process aborts. Only the printed result
+   *  is therefore specific to one build.
+   */
+  static void expect_rejected(const PonoRun & run, const string & message)
+  {
+    EXPECT_FALSE(run.succeeded) << "pono exited cleanly:\n" << run.output;
+    EXPECT_TRUE(contains(run.output, message));
+  }
 };
 
 // The justice condition alone is violated, so the property only holds if the
@@ -83,54 +106,56 @@ class JusticeCliUnitTests : public ::testing::Test
 // engine, cannot prove a property.
 TEST_F(JusticeCliUnitTests, JusticeHonorsFairnessConstraints)
 {
-  const string output =
-      run_pono({ "--justice",
-                 "--engine",
-                 "ind",
-                 input_path("btor2/fair_frozen_mode.btor2") });
-  EXPECT_TRUE(contains(output, "unsat\nj0"));
+  const PonoRun run = run_pono({ "--justice",
+                                 "--engine",
+                                 "ind",
+                                 input_path("btor2/fair_frozen_mode.btor2") });
+  EXPECT_TRUE(contains(run.output, "unsat\nj0"));
 }
 
 // Fair lines do not constrain safety checking, so checking a bad property has
 // to report that they are being ignored.
 TEST_F(JusticeCliUnitTests, FairnessIgnoredWithoutJustice)
 {
-  const string output =
+  const PonoRun run =
       run_pono({ input_path("btor2/fair_with_bad_property.btor2") });
-  EXPECT_TRUE(contains(output, "ignoring 1 fair line"));
+  EXPECT_TRUE(contains(run.output, "ignoring 1 fair line"));
 }
 
 // k-liveness counts one condition, so it has to reject a fairness constraint
 // rather than silently check the justice condition alone.
 TEST_F(JusticeCliUnitTests, KLivenessRejectsFairness)
 {
-  const string output =
-      run_pono({ "--justice",
-                 "--justice-translator",
-                 "klive",
-                 input_path("btor2/fair_frozen_mode.btor2") });
-  EXPECT_TRUE(contains(output, "fairness"));
+  // Matched on enough of the message to tell it apart from a path, which can
+  // itself contain the word "fairness".
+  expect_rejected(run_pono({ "--justice",
+                             "--justice-translator",
+                             "klive",
+                             input_path("btor2/fair_frozen_mode.btor2") }),
+                  "including fairness constraints");
 }
 
 // Errors label the property by the kind that was requested, so a failure
 // under --justice reports j, not b.
 TEST_F(JusticeCliUnitTests, ErrorLabelsPropertyByRequestedKind)
 {
-  const string output =
-      run_pono({ "--justice",
-                 "--prop",
-                 "5",
-                 input_path("btor2/fair_frozen_mode.btor2") });
-  EXPECT_TRUE(contains(output, "error\nj5"));
+  const PonoRun run = run_pono({ "--justice",
+                                 "--prop",
+                                 "5",
+                                 input_path("btor2/fair_frozen_mode.btor2") });
+  expect_rejected(run, "Property index 5");
+#ifdef NDEBUG
+  // Only the build that catches the exception reaches the result printing.
+  EXPECT_TRUE(contains(run.output, "error\nj5"));
+#endif
 }
 
 // The SMV and VMT encoders parse no liveness properties, so --justice has to
 // be refused instead of silently checking an invariant property.
 TEST_F(JusticeCliUnitTests, JusticeRejectedForSmv)
 {
-  const string output =
-      run_pono({ "--justice", input_path("smv/counter.smv") });
-  EXPECT_TRUE(contains(output, "--justice is not supported for smv"));
+  expect_rejected(run_pono({ "--justice", input_path("smv/counter.smv") }),
+                  "--justice is not supported for smv");
 }
 
 }  // namespace pono_tests

--- a/tests/test_justice_cli.cpp
+++ b/tests/test_justice_cli.cpp
@@ -1,0 +1,136 @@
+// Tests that drive the pono executable itself, for justice properties and the
+// fairness constraints that go with them. They cover the wiring in pono.cpp --
+// option handling, property selection and the printed result -- which the
+// library-level tests cannot reach.
+
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+using namespace std;
+
+namespace pono_tests {
+
+class JusticeCliUnitTests : public ::testing::Test
+{
+ protected:
+  // PONO_INPUT_DIR is a macro set using CMake to the test input directory.
+  static string input_path(const string & name)
+  {
+    return string(PONO_INPUT_DIR) + "/" + name;
+  }
+
+  /** Wraps a word in single quotes so the shell takes it literally. */
+  static string quote(const string & word)
+  {
+    string quoted = "'";
+    for (const char c : word) {
+      // A single quote has to leave the quoted run to be escaped.
+      if (c == '\'') {
+        quoted += "'\\''";
+      } else {
+        quoted += c;
+      }
+    }
+    return quoted + "'";
+  }
+
+  /** Runs pono and returns its output, with the standard error stream
+   *  redirected into it, since results go to standard output but the
+   *  diagnostics that accompany them go to standard error.
+   *  @param args the command line arguments to pass
+   *  @return the combined output
+   */
+  static string run_pono(const vector<string> & args)
+  {
+    // PONO_BIN is a macro set using CMake to the executable's location.
+    string command = quote(PONO_BIN);
+    for (const string & arg : args) {
+      command += " " + quote(arg);
+    }
+    command += " 2>&1";
+
+    FILE * pipe = popen(command.c_str(), "r");
+    if (!pipe) {
+      throw runtime_error("could not run: " + command);
+    }
+    string output;
+    char buffer[256];
+    while (fgets(buffer, sizeof(buffer), pipe)) {
+      output += buffer;
+    }
+    pclose(pipe);
+    return output;
+  }
+
+  static ::testing::AssertionResult contains(const string & output,
+                                             const string & expected)
+  {
+    if (output.find(expected) != string::npos) {
+      return ::testing::AssertionSuccess();
+    }
+    return ::testing::AssertionFailure()
+           << "expected to find \"" << expected << "\" in output:\n"
+           << output;
+  }
+};
+
+// The justice condition alone is violated, so the property only holds if the
+// fair line is honored. k-induction is needed because bmc, the default
+// engine, cannot prove a property.
+TEST_F(JusticeCliUnitTests, JusticeHonorsFairnessConstraints)
+{
+  const string output =
+      run_pono({ "--justice",
+                 "--engine",
+                 "ind",
+                 input_path("btor2/fair_frozen_mode.btor2") });
+  EXPECT_TRUE(contains(output, "unsat\nj0"));
+}
+
+// Fair lines do not constrain safety checking, so checking a bad property has
+// to report that they are being ignored.
+TEST_F(JusticeCliUnitTests, FairnessIgnoredWithoutJustice)
+{
+  const string output =
+      run_pono({ input_path("btor2/fair_with_bad_property.btor2") });
+  EXPECT_TRUE(contains(output, "ignoring 1 fair line"));
+}
+
+// k-liveness counts one condition, so it has to reject a fairness constraint
+// rather than silently check the justice condition alone.
+TEST_F(JusticeCliUnitTests, KLivenessRejectsFairness)
+{
+  const string output =
+      run_pono({ "--justice",
+                 "--justice-translator",
+                 "klive",
+                 input_path("btor2/fair_frozen_mode.btor2") });
+  EXPECT_TRUE(contains(output, "fairness"));
+}
+
+// Errors label the property by the kind that was requested, so a failure
+// under --justice reports j, not b.
+TEST_F(JusticeCliUnitTests, ErrorLabelsPropertyByRequestedKind)
+{
+  const string output =
+      run_pono({ "--justice",
+                 "--prop",
+                 "5",
+                 input_path("btor2/fair_frozen_mode.btor2") });
+  EXPECT_TRUE(contains(output, "error\nj5"));
+}
+
+// The SMV and VMT encoders parse no liveness properties, so --justice has to
+// be refused instead of silently checking an invariant property.
+TEST_F(JusticeCliUnitTests, JusticeRejectedForSmv)
+{
+  const string output =
+      run_pono({ "--justice", input_path("smv/counter.smv") });
+  EXPECT_TRUE(contains(output, "--justice is not supported for smv"));
+}
+
+}  // namespace pono_tests


### PR DESCRIPTION
fair lines were parsed into fairvec_ and then dropped, so a file combining justice and fair was checked as if the fair lines were absent. A counterexample must satisfy the fairness constraints as often as the justice conditions, and every liveness prover already consumes a flat condition set, so the two vectors are unioned where both are in scope. Merging the two dispatches on justice_translator_ is what puts them in one scope; it also removes the null Term the KLIVENESS path left behind. -Werror=switch keeps that switch exhaustive, since -Wall is not passed.

fair operands are always bitvectors of width 1, so they need the bool conversion justice conditions already get.

Two further silent failures in the same path: errors labeled the property b even under --justice, and --justice was ignored for SMV and VMT, whose encoders parse no liveness properties.